### PR TITLE
Add .nojekyll file before deploying

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+build_dir='_book'
+
 # Depends on https://github.com/davisp/ghp-import
-gitbook build && \
-ghp-import -b gh-pages _book/ && git push origin gh-pages
+gitbook build . $build_dir && \
+touch $build_dir/.nojekyll && \
+ghp-import -b gh-pages $build_dir && \
+git push origin gh-pages


### PR DESCRIPTION
Github automatically tries to build pages using jekyll. This can cause
errors If markdown pages slip through the build process. Adding the
.nojekyll disables this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/firefox-data-docs/16)
<!-- Reviewable:end -->
