### PR TITLE
Replace RTD with https://firefox-source-docs.mozilla.org/

### DIFF
--- a/concepts/analysis_gotchas.md
+++ b/concepts/analysis_gotchas.md
@@ -2,7 +2,7 @@
 
 When performing analysis on any data there are some mistakes that are easy to make and details that are easy to overlook. Do you know exactly what question you hope to answer? Is your sample representative of your population? Is your result "real"? How precisely can you state your conclusion?
 
-This document is not about those traps. Instead, it is about quirks and pitfalls specific to [Telemetry](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/index.html).
+This document is not about those traps. Instead, it is about quirks and pitfalls specific to [Telemetry](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/index.html).
 
 ### Pseudo-replication
 
@@ -27,8 +27,8 @@ When in doubt, be precise. You're counting _clients_.
 We don't collect the same information from everyone.
 
 Every profile that doesn't have Telemetry disabled sends us "opt-out" Telemetry. This includes:
-* Nearly everything in the [Environment](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/environment.html)
-* Some very specific [Histograms](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/collection/histograms.html), [Scalars](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/collection/scalars.html), and [Events](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/collection/events.html) that are marked `"releaseChannelCollection": "opt-out"`
+* Nearly everything in the [Environment](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/environment.html)
+* Some very specific [Histograms](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/histograms.html), [Scalars](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/scalars.html), and [Events](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html) that are marked `"releaseChannelCollection": "opt-out"`
 
 Most probes are "opt-in": we do not get information from them unless the user opts into sending us this information. Users can opt-in in two ways:
 1. Using Firefox's Options UI to tick the box that gives us permission

--- a/concepts/analysis_intro.md
+++ b/concepts/analysis_intro.md
@@ -1,7 +1,7 @@
 Getting Started with Firefox Data
 =================================
 
-Firefox clients out in the wild send us data as *pings*. [Main pings](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/main-ping.html) contain some combination of *environment* data (e.g. operating system, hardware, Firefox version), *measurements* (e.g. max number of open tabs, time spent running in Javascript garbage collection), and *events* (a work in progress). We have quite a few different pings, but most of our data for Firefox Desktop comes in from main pings.
+Firefox clients out in the wild send us data as *pings*. [Main pings](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html) contain some combination of *environment* data (e.g. operating system, hardware, Firefox version), *measurements* (e.g. max number of open tabs, time spent running in Javascript garbage collection), and *events* (a work in progress). We have quite a few different pings, but most of our data for Firefox Desktop comes in from main pings.
 
 Measurement Types
 ------

--- a/concepts/choosing_a_dataset.md
+++ b/concepts/choosing_a_dataset.md
@@ -19,7 +19,7 @@ take a look at our [tools for experimentation](/tools/experiments.md).
 
 # Main Ping Derived Datasets
 
-The [main ping](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/main-ping.html)
+The [main ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html)
 contains most of the measurements used to track performance and health of Firefox in the wild.
 This ping includes histograms and scalars.
 
@@ -43,7 +43,7 @@ This section describes the derived datasets we provide to make analyzing this da
 
 # Crash Ping Derived Datasets
 
-The [crash ping](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/crash-ping.html)
+The [crash ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/crash-ping.html)
 is captured after the main Firefox process crashes or after a content process crashes,
 whether or not the crash report is submitted to crash-stats.mozilla.org.
 It includes non-identifying metadata about the crash.
@@ -60,7 +60,7 @@ This section describes the derived datasets we provide to make analyzing this da
 
 # New-Profile Derived Datasets
 
-The [new-profile ping](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/new-profile-ping.html)
+The [new-profile ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/new-profile-ping.html)
 is sent from Firefox Desktop on the first session of a newly created profile and contains the initial
 information about the user environment.
 

--- a/datasets/ping_intro.md
+++ b/datasets/ping_intro.md
@@ -2,12 +2,12 @@ We receive data from our users via **pings**.
 There are several types of pings,
 each containing different measurements and sent for different purposes.
 To review a complete list of ping types and their schemata, see 
-[this section of the Mozilla Source Tree Docs](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/index.html).
+[this section of the Mozilla Source Tree Docs](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/index.html).
 
 #### Background and Caveats
 
 The large majority of analyses can be completed using only the
-[main ping](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/main-ping.html).
+[main ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html).
 This ping includes histograms, scalars, and other performance and diagnostic data.
 
 Few analyses actually rely directly on the raw ping data.
@@ -31,6 +31,6 @@ Raw ping data are not available in [re:dash](https://sql.telemetry.mozilla.org/)
 
 #### Further Reading
 
-You can find [the complete ping documentation](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/index.html).
+You can find [the complete ping documentation](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/index.html).
 To augment our data collection, see
 [Collecting New Data](https://developer.mozilla.org/en-US/docs/Mozilla/Performance/Adding_a_new_Telemetry_probe)

--- a/datasets/pings.md
+++ b/datasets/pings.md
@@ -9,4 +9,4 @@
 # Data Reference
 
 You can find the reference documentation for all ping types
-[here](http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/concepts/pings.html).
+[here](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/concepts/pings.html).


### PR DESCRIPTION
Command:
> git grep -l 'http://gecko.readthedocs.io/en/latest/' | xargs sed -i '' -e 's/http:\/\/gecko.readthedocs.io\/en\/latest\//https:\/\/firefox-source-docs.mozilla.org\//g'