### PR TITLE
Bug 1381840 - Add documentation for 1-Day Retention dataset

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -24,6 +24,7 @@
       * [Sync Summary](datasets/batch_view/sync_summary/reference.md)
       * [Addons](datasets/batch_view/addons/reference.md)
       * [Client Count](datasets/batch_view/client_count/reference.md)
+      * [Retention](datasets/batch_view/retention/reference.md)
       * [New Profile](datasets/batch_view/new_profile/reference.md)
       * [Update](datasets/batch_view/update/reference.md)
     * [Experimental Datasets](tools/experiments.md)

--- a/concepts/choosing_a_dataset.md
+++ b/concepts/choosing_a_dataset.md
@@ -45,6 +45,10 @@ This section describes the derived datasets we provide to make analyzing this da
 
 {% include "/datasets/batch_view/heavy_users/intro.md" %}
 
+## retention
+
+{% include "/datasets/batch_view/retention/intro.md" %}
+
 # Crash Ping Derived Datasets
 
 The [crash ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/crash-ping.html)

--- a/datasets/batch_view/retention/intro.md
+++ b/datasets/batch_view/retention/intro.md
@@ -1,0 +1,85 @@
+The `retention` table provides client counts relevant to client retention at a
+1-day granularity. The project is tracked in [Bug 1381840][original_bug]
+
+### Contents
+
+The `retention` table contains a set of attribute columns used to specify a
+cohort of users and a set of metric columns to describe cohort activity. Each
+row contains a permutation of attributes, an approximate set of clients in a
+cohort, and the aggregate engagement metrics.
+
+This table uses the HyperLogLog (HLL) sketch to create an approximate set of
+clients in a cohort. HLL allows counting across overlapping cohorts in a single
+pass while avoiding the problem of double counting. This data-structure has the
+benefit of being compact and performant in the context of retention analysis,
+at the expense of precision. For example, calculating a 7-day retention period
+can be obtained by aggregating over a week of retention data using the union
+operation. With SQL primitive, this requires a recomputation of COUNT DISTINCT
+over `client_id`'s in the 7-day window.
+
+#### Background and Caveats
+
+1. The data starts at 2017-03-06, the [merge date where Nightly started to
+   track Firefox 55 in Mozilla-Central][release_calendar]. However, there was
+not a consistent view into the behavior of first session profiles until the
+[`new_profile` ping][new_profile]. This means much of the data is inaccurate
+before 2017-06-26.
+2. This dataset uses 4-day reporting latency to aggregate at least 99% of the
+   data in a given submission date. This figure is derived from the
+[telemetry-health measurements on submission latency][telemetry-health], with
+the discussion in [Bug 1407410][bug_1407410]. This latency metric was reduced
+Firefox 55 with the introduction of the shutdown ping-sender mechanism.
+3. Caution should be taken before adding new columns. Additional attribute
+   columns will grow the number of rows exponentially.
+4. The number of HLL bits chosen for this dataset is 13. This means the default
+   size of the HLL object is 2^13 bits or 1KiB. This maintains about a 1% error
+on average. See [this table from Algebird's HLL implementation][algebird] for
+more details.
+
+
+#### Accessing the Data
+
+The data is primarily available through [Redash on STMO][stmo] via
+the Presto source. This service has been configured to use predefined HLL
+functions.
+
+The column should first be cast to the HLL type. The scalar
+`cardinality(<hll_column>)` function will approximate the number of unique
+items per HLL object. The aggregate `merge(<hll_column>)` function will perform
+the set union between all objects in a column.
+
+Example: Cast the count column into the appropriate type.
+```sql
+SELECT cast(hll as HLL) as n_profiles_hll FROM retention
+```
+
+Count the number of clients seen over all attribute combinations.
+```sql
+SELECT cardinality(cast(hll as HLL)) FROM retention
+```
+
+Group-by and aggregate client counts over different release channels.
+```sql
+SELECT channel, cardinality(merge(cast(hll AS HLL))
+FROM retention
+GROUP BY channel
+```
+
+The HyperLogLog library wrappers are available for use outside of the
+configured STMO environment, [`spark-hyperloglog`][s-hll] and
+[`presto-hyperloglog`][p-hll].
+
+Also see the [`client_count` dataset][client_count].
+
+
+[original_bug]: https://bugzilla.mozilla.org/show_bug.cgi?id=1381840
+[release_calendar]: https://wiki.mozilla.org/RapidRelease/Calendar
+[new_profile]: ../new_profile/reference.md
+[telemetry-health]: https://sql.telemetry.mozilla.org/dashboard/telemetry-health
+[bug_1407410]: https://bugzilla.mozilla.org/show_bug.cgi?id=1407410
+[algebird]: https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala#L230-L255
+[stmo]: sql.telemetry.mozilla.org
+[s-hll]: https://github.com/mozilla/spark-hyperloglog
+[p-hll]: https://github.com/vitillo/presto-hyperloglog
+[client_count]: ../client_count/reference.md
+

--- a/datasets/batch_view/retention/reference.md
+++ b/datasets/batch_view/retention/reference.md
@@ -1,0 +1,63 @@
+# 1 Day Retention
+
+<!-- toc -->
+
+# Introduction
+
+{% include "./intro.md" %}
+
+# Data Reference
+
+## Example Queries
+
+See the [Example Usage Dashboard][example_usage] for more usages of datasets of
+the same shape.
+
+## Scheduling
+
+The job is scheduled on Airflow on a daily basis after `main_summary` is run
+for the day. This job requires both `mozetl` and `telemetry-batch-view` as
+dependencies.
+
+## Schema
+
+As of 2017-10-10, the current version of `retention` is `v1` and has a schema
+as follows:
+
+```
+root
+ |-- subsession_start: string (nullable = true)
+ |-- profile_creation: string (nullable = true)
+ |-- days_since_creation: long (nullable = true)
+ |-- channel: string (nullable = true)
+ |-- app_version: string (nullable = true)
+ |-- geo: string (nullable = true)
+ |-- distribution_id: string (nullable = true)
+ |-- is_funnelcake: boolean (nullable = true)
+ |-- source: string (nullable = true)
+ |-- medium: string (nullable = true)
+ |-- content: string (nullable = true)
+ |-- sync_usage: string (nullable = true)
+ |-- is_active: boolean (nullable = true)
+ |-- hll: binary (nullable = true)
+ |-- usage_hours: double (nullable = true)
+ |-- sum_squared_usage_hours: double (nullable = true)
+ |-- total_uri_count: long (nullable = true)
+ |-- unique_domains_count: double (nullable = true)
+```
+
+# Code Reference
+
+The ETL script for processing the data before aggregation is found in
+[`mozetl.engagement.retention`][mozetl_job]. The aggregate job is found in
+[telemetry-batch-view][tbv_job] as the `RetentionView`.
+
+The [runner script][airflow_job] performs all the necessary setup to run on
+EMR. This script can be used to perform backfill.
+
+
+
+[example_usage]: https://sql.telemetry.mozilla.org/dashboard/firefox-telemetry-retention-dataset-example-usage
+[mozetl_job]: https://github.com/mozilla/python_mozetl/blob/master/mozetl/engagement/retention/job.py
+[tbv_job]: https://github.com/mozilla/telemetry-batch-view/blob/master/src/main/scala/com/mozilla/telemetry/views/RetentionView.scala
+[airflow_job]: https://github.com/acmiyaguchi/telemetry-airflow/blob/1b4b11d23cdd1191ed2d2be905f116d7c3c67533/jobs/retention.sh


### PR DESCRIPTION
Adds initial documentation for the 1-day Firefox retention dataset.

I originally used numbers for the references at the end of the document, but the templating engine made it messy and had them overlapping. Now it uses short symbols. 