### PR TITLE
Document low-count filtering in the SSL Dataset

### DIFF
--- a/datasets/other/ssl/intro.md
+++ b/datasets/other/ssl/intro.md
@@ -14,6 +14,8 @@ statistics are `reporting_ratio`, `normalized_pageloads`, and `ratio`.
 * We're using normalized values in `normalized_pageloads` to obscure absolute pageload counts.
 * This is across the entirety of release, not per-version, because we're looking at Web health,
 not Firefox user health.
+* Any dimension tuple (any given combination of `submission_date`, `os`, and `country`) with 
+fewer than 5000 pageloads is omitted from the dataset.
 * This is hopefully just a temporary dataset to stopgap release aggregates going away
 until we can come up with a better way to publicly publish datasets.
 


### PR DESCRIPTION
I mentioned this limit [in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1414839#c24) but it's buried and could be of interest to people using this dataset.