### PR TITLE
Add missing headlines to book chapters

### DIFF
--- a/cookbooks/longitudinal_examples.md
+++ b/cookbooks/longitudinal_examples.md
@@ -1,3 +1,5 @@
+# Longitudinal Examples
+
 ### Introduction
 
 The longitudinal dataset is a summary of main pings. If you're not sure which

--- a/cookbooks/new_ping.md
+++ b/cookbooks/new_ping.md
@@ -1,3 +1,5 @@
+# Sending a Custom Ping
+
 Got some new data you want to send to us? How in the world do you send a new ping? Follow this guide
 to find out.
 


### PR DESCRIPTION
This adds the headlines as used in the ToC to the chapter itself.