### PR TITLE
Add documentation for events data flow

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -44,6 +44,7 @@
   * [Overview of Mozilla's Data Pipeline](/concepts/pipeline/data_pipeline.md)
     * [In-depth Data Pipeline Detail](/concepts/pipeline/data_pipeline_detail.md)
     * [HTTP Edge Server Specification](/concepts/pipeline/http_edge_spec.md)
+    * [Event Pipeline Detail](/concepts/pipeline/event_pipeline.md)
   * [Interfaces](tools/interfaces.md)
     * [Analysis Intro / TMO](concepts/analysis_intro.md)
     * [Custom analysis with Spark](tools/spark.md)

--- a/concepts/pipeline/event_pipeline.md
+++ b/concepts/pipeline/event_pipeline.md
@@ -76,6 +76,8 @@ Where the individual fields are:
 - `value`: `String`, optional, may be null. This is a user defined value, providing context for the event.
 - `extra`: `Object`, optional, may be null. This is an object of the form `{"key": "value", ...}`, both keys and values need to be strings. This is used for events when additional richer context is needed.
 
+See also the [Firefox Telemetry documentation](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#serialization-format).
+
 
 # Event data collection
 
@@ -115,7 +117,7 @@ using the [`telemetry-ios`](https://github.com/mozilla-mobile/telemetry-ios) and
 On the pipeline side, the event data is made available in different datasets:
 - [`main_summary`](/concepts/choosing_a_dataset.md#mainsummary) has a row for each main ping and includes
   its event payload.
-- [`events`](/datasets/batch_view/events/reference.md) contains a row for each event received.
+- [`events`](/datasets/batch_view/events/reference.md) contains a row for each event received. See [this sample query](https://sql.telemetry.mozilla.org/queries/52582/source).
 - `telemetry_mobile_event_parquet` contains a row for each mobile event ping. See [this sample query](https://sql.telemetry.mozilla.org/queries/52581/source).
 - `focus_events_longitudinal` currently contains events from Firefox Focus.
 
@@ -126,4 +128,4 @@ The above datasets are all accessible through [Re:dash](/tools/stmo.md) and [Spa
 For product analytics based on event data, we have [Amplitude](https://sso.mozilla.com/amplitude)
 (hosted by the IT data team). We can connect our event data sources data to Amplitude.
 We have an active connector to Amplitude for mobile events, which can push event data over
-daily. For Firefox Desktop events this is planned and available soon.
+daily. For Firefox Desktop events this will be available soon.

--- a/concepts/pipeline/event_pipeline.md
+++ b/concepts/pipeline/event_pipeline.md
@@ -86,12 +86,12 @@ use cases:
 - The [*Telemetry event API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html)
   allows easy recording of events from Firefox code.
 - The [*dynamic event API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#registerevents)
-  allows code from Mozilla add-ons to record new events into Telemetry without shipping Firefox
+  allows code from Mozilla addons to record new events into Telemetry without shipping Firefox
   code.
-- The *Telemetry extension API* ([WIP](https://bugzilla.mozilla.org/show_bug.cgi?id=1280234))
+- The *Telemetry extension API* ([work in progress](https://bugzilla.mozilla.org/show_bug.cgi?id=1280234))
   will allow Mozilla extensions to record new events into Telemetry.
 - The [*Hybrid-content API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/hybrid-content.html)
-  allows specific whitelisted Mozilla content code to record new events into Telemetry.
+  allows specific white-listed Mozilla content code to record new events into Telemetry.
 
 For all these APIs, events will get sent to the pipeline through the
 [main ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html),
@@ -105,8 +105,8 @@ can follow the event data format and potentially connect to the existing tooling
 ## Mobile event collection
 
 On mobile, event data is currently collected through the [`focus-events` ping](https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service#event-ping),
-using the [telemetry-ios](https://github.com/mozilla-mobile/telemetry-ios) and
-[telemetry-android](https://github.com/mozilla-mobile/telemetry-android) libraries.
+using the [`telemetry-ios`](https://github.com/mozilla-mobile/telemetry-ios) and
+[`telemetry-android`](https://github.com/mozilla-mobile/telemetry-android) libraries.
 In the future event data will be mainly collected through the planned mobile events ping.
 
 # Datasets
@@ -119,7 +119,7 @@ On the pipeline side, the event data is made available in different datasets:
 
 # Data tooling
 
-The above datasets are all accessible through [Redash](/tools/stmo.md) and [Spark jobs](/tools/stmo.md).
+The above datasets are all accessible through [Re:dash](/tools/stmo.md) and [Spark jobs](/tools/stmo.md).
 
 For product analytics based on event data, we have [Amplitude](https://sso.mozilla.com/amplitude)
 (hosted by the IT data team). We can connect our event data sources data to Amplitude.

--- a/concepts/pipeline/event_pipeline.md
+++ b/concepts/pipeline/event_pipeline.md
@@ -1,0 +1,127 @@
+# Event Data Pipeline
+
+We collect event-oriented data from different sources. This data is collected and processed in a
+specific path through our data pipeline, which we will detail here.
+
+```mermaid
+graph TD
+fx_code(fa:fa-cog Firefox code) --> firefox(fa:fa-firefox Firefox Telemetry)
+fx_extensions(fa:fa-cog Mozilla extensions) --> firefox
+fx_hybrid(fa:fa-cog Hybrid Content) --> firefox
+mobile(fa:fa-cog Mobile products) --> mobile_telemetry(fa:fa-firefox Mobile Telemetry)
+firefox -->|main ping| pipeline((fa:fa-database Firefox Data Pipeline))
+firefox -.->|events ping, planned| pipeline
+mobile_telemetry --> |mobile events ping| pipeline
+pipeline -->|Firefox events| main_summary[fa:fa-bars main summary table]
+main_summary --> events_table[fa:fa-bars events table]
+pipeline -->|Mobile events| focus_events_table[fa:fa-bars mobile events table]
+main_summary --> redash(fa:fa-bar-chart Redash)
+events_table --> redash
+events_table -.->|planned| amplitude(fa:fa-bar-chart Amplitude)
+focus_events_table --> redash
+focus_events_table --> amplitude
+
+style fx_code fill:#f94,stroke-width:0px
+style fx_extensions fill:#f94,stroke-width:0px
+style fx_hybrid fill:#f94,stroke-width:0px
+style mobile fill:#f94,stroke-width:0px
+style firefox fill:#f61,stroke-width:0px
+style mobile_telemetry fill:#f61,stroke-width:0px
+style pipeline fill:#79d,stroke-width:0px
+style main_summary fill:lightblue,stroke-width:0px
+style events_table fill:lightblue,stroke-width:0px
+style mobile_events_table fill:lightblue,stroke-width:0px
+style redash fill:salmon,stroke-width:0px
+style amplitude fill:salmon,stroke-width:0px
+```
+
+# Overview
+
+Across the different Firefox teams there is a common need for a more fine grained understanding of
+product usage, like understanding the order of interactions or how they occur over time.
+To address that our data pipeline needs to support working with event-oriented data.
+
+We specify a common event data format, which allows for broader, shared usage of data processing tools.
+To make working with event data feasible, we provide different mechanisms to get the event data
+from products to our data pipeline and make the data available in tools for analysis.
+
+# The event format
+
+Events are submitted as an array, e.g.:
+
+```javascript
+[
+  [2147, "ui", "click", "back_button"],
+  [2213, "ui", "search", "search_bar", "google"],
+  [2892, "ui", "completion", "search_bar", "yahoo",
+    {"querylen": "7", "results": "23"}],
+  [5434, "dom", "load", "frame", null,
+    {"prot": "https", "src": "script"}],
+  // ...
+]
+```
+
+Each event is of the form:
+
+```javascript
+[timestamp, category, method, object, value, extra]
+```
+
+Where the individual fields are:
+
+- `timestamp`: `Number`, positive integer. This is the time in ms when the event was recorded, relative to the main process start time.
+- `category`: `String`, identifier. The category is a group name for events and helps to avoid name conflicts.
+- `method`: `String`, identifier. This describes the type of event that occurred, e.g. `click`, `keydown` or `focus`.
+- `object`: `String`, identifier. This is the object the event occurred on, e.g. `reload_button` or `urlbar`.
+- `value`: `String`, optional, may be null. This is a user defined value, providing context for the event.
+- `extra`: `Object`, optional, may be null. This is an object of the form `{"key": "value", ...}`, both keys and values need to be strings. This is used for events when additional richer context is needed.
+
+
+# Event data collection
+
+## Firefox event collection
+
+To collect this event data in Firefox there are different APIs in Firefox, all addressing different
+use cases:
+- The [*Telemetry event API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html)
+  allows easy recording of events from Firefox code.
+- The [*dynamic event API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#registerevents)
+  allows code from Mozilla add-ons to record new events into Telemetry without shipping Firefox
+  code.
+- The *Telemetry extension API* ([WIP](https://bugzilla.mozilla.org/show_bug.cgi?id=1280234))
+  will allow Mozilla extensions to record new events into Telemetry.
+- The [*Hybrid-content API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/hybrid-content.html)
+  allows specific whitelisted Mozilla content code to record new events into Telemetry.
+
+For all these APIs, events will get sent to the pipeline through the
+[main ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html),
+with a hard limit of 500 events per ping.
+In the future, Firefox events will be sent through a separate *events ping*, removing the hard limit.
+As of Firefox 61, all events recorded through these APIs are [automatically counted in scalars](https://bugzilla.mozilla.org/show_bug.cgi?id=1440673).
+
+Finally, [*custom pings*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/custom-pings.html)
+can follow the event data format and potentially connect to the existing tooling with some integration work.
+
+## Mobile event collection
+
+On mobile, event data is currently collected through the [`focus-events` ping](https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service#event-ping),
+using the [telemetry-ios](https://github.com/mozilla-mobile/telemetry-ios) and
+[telemetry-android](https://github.com/mozilla-mobile/telemetry-android) libraries.
+In the future event data will be mainly collected through the planned mobile events ping.
+
+# Datasets
+
+On the pipeline side, the event data is made available in different datasets:
+- [`main_summary`](/concepts/choosing_a_dataset.md#mainsummary) has a row for each main ping and includes
+  its event payload.
+- [`events`](/datasets/batch_view/events/reference.md) contains a row for each event received.
+- `focus_events_longitudinal` contains the current mobile events.
+
+# Data tooling
+
+The above datasets are all accessible through [Redash](/tools/stmo.md) and [Spark jobs](/tools/stmo.md).
+
+For product analytics based on event data, we have [Amplitude](https://sso.mozilla.com/amplitude)
+(hosted by the IT data team). We can connect our event data sources data to Amplitude.
+We have an active connector to Amplitude for mobile events, which can push event data over
+daily. For Firefox Desktop events this is planned and available soon.

--- a/concepts/pipeline/event_pipeline.md
+++ b/concepts/pipeline/event_pipeline.md
@@ -14,12 +14,12 @@ firefox -.->|events ping, planned| pipeline
 mobile_telemetry --> |mobile events ping| pipeline
 pipeline -->|Firefox events| main_summary[fa:fa-bars main summary table]
 main_summary --> events_table[fa:fa-bars events table]
-pipeline -->|Mobile events| focus_events_table[fa:fa-bars mobile events table]
+pipeline -->|Mobile events| mobile_events_table[fa:fa-bars mobile events table]
 main_summary --> redash(fa:fa-bar-chart Redash)
 events_table --> redash
 events_table -.->|planned| amplitude(fa:fa-bar-chart Amplitude)
-focus_events_table --> redash
-focus_events_table --> amplitude
+mobile_events_table --> redash
+mobile_events_table --> amplitude
 
 style fx_code fill:#f94,stroke-width:0px
 style fx_extensions fill:#f94,stroke-width:0px
@@ -30,7 +30,7 @@ style mobile_telemetry fill:#f61,stroke-width:0px
 style pipeline fill:#79d,stroke-width:0px
 style main_summary fill:lightblue,stroke-width:0px
 style events_table fill:lightblue,stroke-width:0px
-style focus_events_table fill:lightblue,stroke-width:0px
+style mobile_events_table fill:lightblue,stroke-width:0px
 style redash fill:salmon,stroke-width:0px
 style amplitude fill:salmon,stroke-width:0px
 ```
@@ -104,10 +104,11 @@ can follow the event data format and potentially connect to the existing tooling
 
 ## Mobile event collection
 
-On mobile, event data is currently collected through the [`focus-events` ping](https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service#event-ping),
+Mobile events data primarily flows through the mobile events ping ([ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/dev/schemas/telemetry/mobile-event)), from e.g. [Firefox iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Event-Tracking-with-Mozilla's-Telemetry-Service#event-ping), Firefox for Fire TV and Rocket.
+
+Currently we also collect event data from Firefox Focus through the [`focus-events` ping](https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service#event-ping),
 using the [`telemetry-ios`](https://github.com/mozilla-mobile/telemetry-ios) and
 [`telemetry-android`](https://github.com/mozilla-mobile/telemetry-android) libraries.
-In the future event data will be mainly collected through the planned mobile events ping.
 
 # Datasets
 
@@ -115,7 +116,8 @@ On the pipeline side, the event data is made available in different datasets:
 - [`main_summary`](/concepts/choosing_a_dataset.md#mainsummary) has a row for each main ping and includes
   its event payload.
 - [`events`](/datasets/batch_view/events/reference.md) contains a row for each event received.
-- `focus_events_longitudinal` contains the current mobile events.
+- `telemetry_mobile_event_parquet` contains a row for each mobile event ping. See [this sample query](https://sql.telemetry.mozilla.org/queries/52581/source).
+- `focus_events_longitudinal` currently contains events from Firefox Focus.
 
 # Data tooling
 

--- a/concepts/pipeline/event_pipeline.md
+++ b/concepts/pipeline/event_pipeline.md
@@ -30,7 +30,7 @@ style mobile_telemetry fill:#f61,stroke-width:0px
 style pipeline fill:#79d,stroke-width:0px
 style main_summary fill:lightblue,stroke-width:0px
 style events_table fill:lightblue,stroke-width:0px
-style mobile_events_table fill:lightblue,stroke-width:0px
+style focus_events_table fill:lightblue,stroke-width:0px
 style redash fill:salmon,stroke-width:0px
 style amplitude fill:salmon,stroke-width:0px
 ```

--- a/concepts/pipeline/event_pipeline.md
+++ b/concepts/pipeline/event_pipeline.md
@@ -119,7 +119,7 @@ On the pipeline side, the event data is made available in different datasets:
 
 # Data tooling
 
-The above datasets are all accessible through [Re:dash](/tools/stmo.md) and [Spark jobs](/tools/stmo.md).
+The above datasets are all accessible through [Re:dash](/tools/stmo.md) and [Spark jobs](/tools/spark.md).
 
 For product analytics based on event data, we have [Amplitude](https://sso.mozilla.com/amplitude)
 (hosted by the IT data team). We can connect our event data sources data to Amplitude.

--- a/datasets/batch_view/events/reference.md
+++ b/datasets/batch_view/events/reference.md
@@ -30,6 +30,8 @@ The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/master/dags/
 Firefox has an API to record events, which are then submitted through the main ping.
 The format and mechanism of event collection in Firefox is documented [here](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html).
 
+The full events data pipeline is [documented here](/concepts/pipeline/event_pipeline.md).
+
 ## Schema
 
 As of 2017-01-26, the current version of the `events` dataset is `v1`, and has a schema as follows:


### PR DESCRIPTION
This adds an overview of how event data flows through our data pipeline end-to-end.

For now this is mostly aimed at what users need to know, so i can link
something proper in the newsletter.
I'd love to see more technical detail in this later, but i think this scope is sufficient for a first pass.