### PR TITLE
Document the Socorro Crash Report dataset (#136)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -54,6 +54,7 @@
     * [Main Summary](datasets/batch_view/main_summary/reference.md)
     * [New Profile](datasets/batch_view/new_profile/reference.md)
     * [Retention](datasets/batch_view/retention/reference.md)
+    * [Socorro Crash Reports](datasets/other/socorro_crash/reference.md)
     * [SSL Ratios (public)](datasets/other/ssl/reference.md)
     * [Sync Summary](datasets/batch_view/sync_summary/reference.md)
     * [Update](datasets/batch_view/update/reference.md)

--- a/concepts/choosing_a_dataset.md
+++ b/concepts/choosing_a_dataset.md
@@ -86,6 +86,10 @@ This data is available in the `telemetry_new_profile_parquet` dataset.
 
 {% include "/datasets/batch_view/update/intro.md" %}
 
+# Other Datasets
+
+{% include "/datasets/other/socorro_crash/intro.md" %}
+
 # Obsolete Datasets
 
 ## `heavy_users`

--- a/datasets/other/socorro_crash/intro.md
+++ b/datasets/other/socorro_crash/intro.md
@@ -5,5 +5,5 @@ A nightly import job converts batches of JSON documents into a columnar format u
 ### Contents
 #### Accessing the Data
 The dataset is available in parquet at `s3://telemetry-parquet/socorro_crash/v2`.
-It is also indexed with Athena and Preso with the table name `socorro_crash`.
+It is also indexed with Athena and Presto with the table name `socorro_crash`.
 

--- a/datasets/other/socorro_crash/intro.md
+++ b/datasets/other/socorro_crash/intro.md
@@ -1,0 +1,9 @@
+Public crash statistics for Firefox are available through the Data Platform in a `socorro_crash` dataset.
+The crash data in [Socorro](https://wiki.mozilla.org/Socorro) is sanitized and made available to ATMO and STMO.
+A nightly import job converts batches of JSON documents into a columnar format using the associated JSON Schema. 
+
+### Contents
+#### Accessing the Data
+The dataset is available in parquet at `s3://telemetry-parquet/socorro_crash/v2`.
+It is also indexed with Athena and Preso with the table name `socorro_crash`.
+

--- a/datasets/other/socorro_crash/reference.md
+++ b/datasets/other/socorro_crash/reference.md
@@ -33,8 +33,7 @@ The job is schedule on a nightly basis on airflow.
 The dag is available under [`mozilla/telemetry-airflow:/dags/socorro_import.py`](https://github.com/mozilla/telemetry-airflow/blob/930790116d8d5c924cd61a07311fc8a34340f3d6/dags/socorro_import.py).
 
 ### Schema 
-The source schema is available on the [`mozilla/socorro` GitHub repository](https://raw.githubusercontent.com/mozilla/socorro/master/socorro/schemas/crash_report.json
-).
+The source schema is available on the [`mozilla/socorro` GitHub repository](https://raw.githubusercontent.com/mozilla/socorro/master/socorro/schemas/crash_report.json).
 This schema is transformed into a Spark-SQL structure and serialized to parquet after transforming column names from `camelCase` to `snake_case`.
 
 

--- a/datasets/other/socorro_crash/reference.md
+++ b/datasets/other/socorro_crash/reference.md
@@ -1,0 +1,40 @@
+# Socorro Crash Reports
+
+<!-- toc -->
+
+## Introduction
+
+{% include "./intro.md" %}
+
+## Data Reference
+
+### Example
+
+The dataset can be queried using SQL. The following example will aggregate counts and uptime broken down by date and reason.
+
+```sql
+SELECT crash_date,
+       reason,
+       count(*) as n_crashes,
+       avg(uptime) as avg_uptime,
+       stddev(uptime) as stddev_uptime,
+       approx_percentile(uptime, ARRAY [0.25, 0.5, 0.75]) as qntl_uptime
+FROM socorro_crash
+WHERE crash_date='20180520'
+GROUP BY 1,
+         2
+```
+
+[STMO Source](https://sql.telemetry.mozilla.org/queries/53884/source)
+
+### Scheduling
+The job is schedule on a nightly basis on airflow. The dag is available under [`mozilla/telemetry-airflow:/dags/socorro_import.py`](https://github.com/mozilla/telemetry-airflow/blob/930790116d8d5c924cd61a07311fc8a34340f3d6/dags/socorro_import.py).
+
+### Schema 
+The source schema is available on the [`mozilla/socorro` github repository](https://raw.githubusercontent.com/mozilla/socorro/master/socorro/schemas/crash_report.json
+). This schema is transformed into a SparkSQL structure and serialized to parquet after transforming column names from camelCase to snake_case.
+
+
+### Code Reference
+
+The code is [a notebook in the `mozilla-services/data-pipeline` repository](https://github.com/mozilla-services/data-pipeline/blob/master/reports/socorro_import/ImportCrashData.ipynb).

--- a/datasets/other/socorro_crash/reference.md
+++ b/datasets/other/socorro_crash/reference.md
@@ -10,7 +10,8 @@
 
 ### Example
 
-The dataset can be queried using SQL. The following example will aggregate counts and uptime broken down by date and reason.
+The dataset can be queried using SQL.
+For example, we can aggregate the number of crashes and total up-time by date and reason.
 
 ```sql
 SELECT crash_date,
@@ -28,11 +29,13 @@ GROUP BY 1,
 [STMO Source](https://sql.telemetry.mozilla.org/queries/53884/source)
 
 ### Scheduling
-The job is schedule on a nightly basis on airflow. The dag is available under [`mozilla/telemetry-airflow:/dags/socorro_import.py`](https://github.com/mozilla/telemetry-airflow/blob/930790116d8d5c924cd61a07311fc8a34340f3d6/dags/socorro_import.py).
+The job is schedule on a nightly basis on airflow.
+The dag is available under [`mozilla/telemetry-airflow:/dags/socorro_import.py`](https://github.com/mozilla/telemetry-airflow/blob/930790116d8d5c924cd61a07311fc8a34340f3d6/dags/socorro_import.py).
 
 ### Schema 
-The source schema is available on the [`mozilla/socorro` github repository](https://raw.githubusercontent.com/mozilla/socorro/master/socorro/schemas/crash_report.json
-). This schema is transformed into a SparkSQL structure and serialized to parquet after transforming column names from camelCase to snake_case.
+The source schema is available on the [`mozilla/socorro` GitHub repository](https://raw.githubusercontent.com/mozilla/socorro/master/socorro/schemas/crash_report.json
+).
+This schema is transformed into a Spark-SQL structure and serialized to parquet after transforming column names from `camelCase` to `snake_case`.
 
 
 ### Code Reference


### PR DESCRIPTION
This adds documentation for the `Crash Report Import` job and data-set usage. 

r? @mreid-moz for being the reviewer during the job implementation and scheduling
f? @willkg: are there any other points that you'd like to see in the documentation page?