### PR TITLE
Add Databricks to list of data analysis tools

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -15,6 +15,7 @@ analytics
 APIs
 AsciiDoc
 ATMO
+autoscaling
 Awesomebar
 AWS
 backend

--- a/tools/interfaces.md
+++ b/tools/interfaces.md
@@ -29,6 +29,14 @@ programming skills and knowledge of various data APIs. Learn more by visiting
 the [documentation](https://wiki.mozilla.org/Telemetry) or
 [tutorials](spark.md).
 
+#### [Databricks](https://dbc-caf9527b-e073.cloud.databricks.com/)
+
+Offers notebook interface with shared, always-on, autoscaling cluster
+(attaching your notebooks to `shared_serverless` is the best way to start).  
+Convenient for quick data investigations. Users can get help on `#databricks`
+channel on IRC and are advised to join the 
+[`databricks-discuss@mozilla.com`](https://groups.google.com/a/mozilla.com/forum/#!forum/databricks-discuss) group.
+
 #### [`telemetry.mozilla.org`](analysis_intro.md) (TMO)
 
 Our [`telemetry.mozilla.org`](https://telemetry.mozilla.org) (TMO) site is the


### PR DESCRIPTION
`Analysis interfaces` page is missing Databricks mention.