### PR TITLE
Parallelize link check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - "4.1"
+addons:
+  apt:
+    packages:
+      - parallel
 install:
   - npm install gitbook-cli markdown-spellcheck markdown-link-check -g
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ addons:
       - parallel
 install:
   - npm install gitbook-cli markdown-spellcheck markdown-link-check -g
-script:
   - gitbook install
+script:
   - gitbook build
   - mdspell '**/*.md' '!**/node_modules/**/*.md' '!**/_book/**/*.md' --ignore-numbers --en-us --report
   - bash scripts/link_check.sh

--- a/scripts/link_check.sh
+++ b/scripts/link_check.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# If there are any failures along the way, exit nonzero.
-EXIT_CODE=0
-for f in $(find . -name "*.md" | grep -v "_book" | grep -v "node_modules" | sort); do
-    markdown-link-check --quiet --config .linkcheck.json $f
-    RC=$?
-    if [ "$RC" -ne "0" ]; then
-        EXIT_CODE=$RC
-    fi
-done
+if command -v parallel > /dev/null; then
+  RUNNER="parallel --will-cite"
+else
+  RUNNER=xargs
+fi
 
-exit $EXIT_CODE
+find . -name "*.md" |\
+  grep -v "_book" |\
+  grep -v "node_modules" |\
+  sort |\
+  $RUNNER -P 8 markdown-link-check --quiet --verbose --config .linkcheck.json

--- a/scripts/link_check.sh
+++ b/scripts/link_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if command -v parallel > /dev/null; then
-  RUNNER="parallel --will-cite"
+  RUNNER="parallel"
 else
   RUNNER="xargs -n1"
 fi

--- a/scripts/link_check.sh
+++ b/scripts/link_check.sh
@@ -3,7 +3,7 @@
 if command -v parallel > /dev/null; then
   RUNNER="parallel --will-cite"
 else
-  RUNNER=xargs
+  RUNNER="xargs -n1"
 fi
 
 find . -name "*.md" |\


### PR DESCRIPTION
Speed up CI a little and get more verbose reporting on failures so we can diagnose sporadic link-check failures better.