### PR TITLE
Bug 1508697 - Updates to search documentation

### DIFF
--- a/src/datasets/mozetl/search_aggregates/intro.md
+++ b/src/datasets/mozetl/search_aggregates/intro.md
@@ -18,13 +18,13 @@ Unless otherwise noted, these columns are taken directly from `main_summary`.
 * `source` - The UI component used to issue a search - e.g. `urlbar`, `abouthome`
 * `country`
 * `locale`
-* `addon_version` - The installed version of the [`followonsearch` addon]
+* `addon_version` - The installed version of the [`followonsearch` addon] (before version 61)
 * `app_version`
 * `distribution_id` - `NULL` means the standard Firefox build
 * `search_cohort` - `NULL` except for small segments relating to search experimentation
 
-There are three aggregation columns:
-`sap`, `tagged-sap`, and `tagged-follow-on`.
+There are five aggregation columns:
+`sap`, `tagged-sap`, and `tagged-follow-on`, `organic` and `unknown`.
 Each of these columns represent different types of searches.
 For more details, see the [search data documentation]
 Note that, if there were no such searches in a row's segment

--- a/src/datasets/mozetl/search_aggregates/reference.md
+++ b/src/datasets/mozetl/search_aggregates/reference.md
@@ -25,8 +25,8 @@ to run daily.
 
 ## Schema
 
-As of 2018-02-13,
-the current version of `search_aggregates` is `v3`,
+As of 2018-11-28,
+the current version of `search_aggregates` is `v4`,
 and has a schema as follows.
 The dataset is backfilled through 2016-06-06
 
@@ -44,6 +44,8 @@ root
  |-- tagged-sap: long (nullable = true)
  |-- tagged-follow-on: long (nullable = true)
  |-- sap: long (nullable = true)
+ |-- organic: long (nullable = true)
+ |-- unknown: long (nullable = true)
 ```
 
 # Code Reference

--- a/src/datasets/mozetl/search_clients_daily/intro.md
+++ b/src/datasets/mozetl/search_clients_daily/intro.md
@@ -14,8 +14,8 @@ In the event that a client sends multiple pings on a given `submission_date`
 we choose an arbitrary value from the pings for that (`client_id`, `submission_date`),
 unless otherwise noted.
 
-There are three standard search count aggregation columns:
-`sap`, `tagged-sap`, and `tagged-follow-on`.
+There are five standard search count aggregation columns:
+`sap`, `tagged-sap`, and `tagged-follow-on`, `organic` and `unknown`.
 Note that, if there were no such searches in a row's segment
 (i.e. the count would be 0),
 the column value is `null`.

--- a/src/datasets/mozetl/search_clients_daily/reference.md
+++ b/src/datasets/mozetl/search_clients_daily/reference.md
@@ -24,7 +24,7 @@ This dataset is scheduled on Airflow
 
 ## Schema
 
-As of 2018-03-23, the current version of `search_clients_daily` is `v2`,
+As of 2018-11-28, the current version of `search_clients_daily` is `v4`,
 and has a schema as follows.
 It's backfilled through 2016-06-07
 
@@ -59,6 +59,8 @@ root
  |-- sap: long (nullable = true)
  |-- tagged_sap: long (nullable = true)
  |-- tagged_follow_on: long (nullable = true)
+ |-- organic: long (nullable = true)
+ |-- unknown: long (nullable = true)
  |-- submission_date_s3: string (nullable = true)
 ```
 

--- a/src/datasets/search.md
+++ b/src/datasets/search.md
@@ -72,7 +72,7 @@ we include our partner code in the URL of the resulting search.
 **Untagged queries** are queries that **do not include one of our partner codes**.
 If a query is untagged,
 it's usually because we do not have a partner deal for that search engine and region
-(or it is an organic search that did not go through us).
+(or it is an organic search that did not start from an SAP).
 
 If an SAP query is tagged, any follow-on query should also be tagged.
 

--- a/src/datasets/search.md
+++ b/src/datasets/search.md
@@ -91,7 +91,7 @@ The **`sap` column counts all SAP (or direct) searches**.
 within the Firefox UI
 These counts are **very reliable, but do not count follow-on queries**.
 
-In 2017-06 we deployed the [followonsearch addon], which adds probes for `tagged-sap` and `tagged-follow-on` searches.
+In 2017-06 we deployed the [`followonsearch` addon], which adds probes for `tagged-sap` and `tagged-follow-on` searches.
 These columns **attempt to count all tagged searches**
 by looking for Mozilla partner codes in the URL of requests to partner search engines.
 These search counts are critical to understanding revenue
@@ -147,8 +147,8 @@ for a notable example.
 
 ## Limited historical data
 
-The [followonsearch addon] was first deployed in 2017-06.
+The [`followonsearch` addon] was first deployed in 2017-06.
 There is no `tagged-*` search data available before this.
 
-[followonsearch addon]: https://github.com/mozilla/followonsearch
+[`followonsearch` addon]: https://github.com/mozilla/followonsearch
 [search permissions template]: https://bugzilla.mozilla.org/enter_bug.cgi?assigned_to=rharter%40mozilla.com&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&comment=Please%20add%20the%20following%20user%20to%20the%20Search%20group%3A%0D%0A%0D%0AMozilla%20email%20address%3A%0D%0AGithub%20handle%3A&component=Datasets%3A%20Search&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-4=X&flag_type-607=X&flag_type-800=X&flag_type-803=X&flag_type-916=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Linux&priority=--&product=Data%20Platform%20and%20Tools&rep_platform=x86_64&short_desc=Add%20user%20to%20search%20user%20groups&target_milestone=---&version=unspecified

--- a/src/datasets/search.md
+++ b/src/datasets/search.md
@@ -2,9 +2,10 @@
 
 ## Introduction
 
-This article introduces the datasets we maintain for search analyses.
-After reading this article,
-you should understand the search datasets well enough to produce moderately complex analyses.
+This article introduces the datasets we maintain for search analyses:
+`search_aggregates` and `search_clients_daily`. After reading this article,
+you should understand the search datasets well enough to produce moderately
+complex analyses.
 
 ## Table of Contents
 
@@ -29,12 +30,12 @@ via the standard `Presto` data source**, even with proper permissions.
 
 ## Direct vs Follow-on Search
 
-Searches can be split into two major classes: *direct* and *follow-on*.
+Searches can be split into three major classes: *sap*, *follow-on*, and *organic*.
 
-Direct searches result from a direct interaction with a `search access point` (SAP),
+SAP searches result from a direct interaction with a `search access point` (SAP),
 which is part of the Firefox UI.
 These searches are often called SAP searches.
-There are currently 6 SAPs:
+There are currently 7 SAPs:
 
 * `urlbar` - entering a search query in the Awesomebar
 * `searchbar` - the main search bar; not present by default for new profiles on Firefox 57+
@@ -42,6 +43,7 @@ There are currently 6 SAPs:
 * `abouthome` - the search bar on the `about:home` page
 * `contextmenu` - selecting text and clicking "Search" from the context menu
 * `system` - starting Firefox from the command line with an option that immediately makes a search
+* `webextension` - initiated from a web extension ([added](https://bugzilla.mozilla.org/show_bug.cgi?id=1492233) as of Firefox 63)
 
 Users will often interact with the Search Engine Results Page (SERP)
 to create "downstream" queries.
@@ -56,6 +58,9 @@ For example, follow-on queries can be caused by:
 * Clicking on the "next" button
 * Accepting spelling suggestions
 
+Finally, we track the number of *organic* searches. These would be searches initiated directly
+from a search engine provider, not through a search access point.
+
 ## Tagged vs Untagged Searches
 
 Our partners (search engines) attribute queries to Mozilla using **partner codes**.
@@ -66,27 +71,27 @@ we include our partner code in the URL of the resulting search.
 
 **Untagged queries** are queries that **do not include one of our partner codes**.
 If a query is untagged,
-it's usually because we do not have a partner deal for that search engine and region.
+it's usually because we do not have a partner deal for that search engine and region
+(or it is an organic search that did not go through us).
 
 If an SAP query is tagged, any follow-on query should also be tagged.
 
 # Standard Search Aggregates
 
-We report three types of searches in our search datasets:
-`SAP`, `tagged-sap`, and `tagged-follow-on`.
+We report five types of searches in our search datasets:
+`sap`, `tagged-sap`, `tagged-follow-on`, `organic`, and `unknown`.
 These aggregates show up as columns in the
 `search_aggregates` and `search_clients_daily` datasets.
 Our search datasets are all derived from `main_summary`.
 The aggregate columns are derived from the `SEARCH_COUNTS` histogram.
 
-The **`SAP` column counts all SAP (or direct) searches**.
-`SAP` search counts are collected via
+The **`sap` column counts all SAP (or direct) searches**.
+`sap` search counts are collected via
 [probes](https://firefox-source-docs.mozilla.org/browser/browser/BrowserUsageTelemetry.html#search-telemetry)
 within the Firefox UI
 These counts are **very reliable, but do not count follow-on queries**.
 
-In 2017-06 we deployed the [`followonsearch` addon],
-which adds probes for `tagged-sap` and `tagged-follow-on` searches.
+In 2017-06 we deployed the [followonsearch addon], which adds probes for `tagged-sap` and `tagged-follow-on` searches.
 These columns **attempt to count all tagged searches**
 by looking for Mozilla partner codes in the URL of requests to partner search engines.
 These search counts are critical to understanding revenue
@@ -94,9 +99,23 @@ since they exclude untagged searches and include follow-on searches.
 However, these search counts have **important caveats affecting their reliability**.
 See [In Content Telemetry Issues](#in-content-telemetry-issues) for more information.
 
+In 2018, we
+[incorporated](https://bugzilla.mozilla.org/show_bug.cgi?id=1475571) this code
+into the product (as of version 61) and also started tracking so-called
+"organic" searches that weren't initiated through a search access point (sap).
+This data has the same caveats as those for follow on searches, above.
+
+We also started tracking "unknown" searches, which generally correspond
+to clients submitting random/unknown search data to our servers as part
+of their telemetry payload. This category can generally safely be ignored, unless its value
+is extremely high (which indicates a bug in either Firefox or the aggregation code
+which creates our datasets).
+
 In `main_summary`, all of these searches are stored in `search_counts.count`,
 **which makes it easy to over count searches**.
-Avoid using `main_summary` for search analyses.
+However, in general, please avoid using `main_summary` for search analyses --
+it's slow and you will need to duplicate much of the work done to make
+analyses of our search datasets tractable.
 
 ## Outlier Filtering
 
@@ -106,18 +125,18 @@ We remove search count observations representing more than
 
 # In Content Telemetry Issues
 
-The [`followonsearch` addon] implements the probe
-used to measure `tagged-sap` and `tagged-follow-on` searches.
-This probe is critical to understanding our revenue.
-It's the only tool that gives us a view of follow-on searches
+The search code module inside Firefox (formerly implemented
+as an addon until version 60) implements the probe used to measure `tagged-sap` and
+`tagged-follow-on` searches and also tracks organic searches. This probe is critical
+to understanding our revenue. It's the only tool that gives us a view of follow-on searches
 and differentiates between tagged and untagged queries.
 However, it comes with some notable caveats.
 
 ## Relies on whitelists
 
-The [`followonsearch` addon] attempts to count all tagged searches
+Firefox's search module attempts to count all tagged searches
 by looking for Mozilla partner codes in the URL of requests to partner search engines.
-To do this, the addon relies on a whitelist of partner codes and URL formats.
+To do this, it relies on a whitelist of partner codes and URL formats.
 The list of partner codes is incomplete and only covers a few top partners.
 These codes also occasionally change so there will be gaps in the data.
 
@@ -126,17 +145,9 @@ See
 [this query](https://sql.telemetry.mozilla.org/queries/47631/source#128887)
 for a notable example.
 
-## Addon uptake
-
-This probe is shipped as an addon.
-Versions 55 and greater have the addon installed by default
-([Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1369028)).
-The addon was deployed to older versions of Firefox via GoFaster,
-but uptake is not 100%.
-
 ## Limited historical data
 
-The addon was first deployed in 2017-06.
+The [followonsearch addon] was first deployed in 2017-06.
 There is no `tagged-*` search data available before this.
 
 [followonsearch addon]: https://github.com/mozilla/followonsearch


### PR DESCRIPTION
* Update to talk about organic and unknown aggregations
* Note that we now track organic and follow on searches inside Firefox
  itself (not through an add-on anymore)
* Other minor clarifications