### PR TITLE
Add DAU documentation and clean up metrics pages

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -33,8 +33,9 @@
     * [Seeing Your Own Pings](cookbooks/view_pings_cep.md)
     * [CEP Matcher](tools/cep_matcher.md)
   * [Metrics](cookbooks/metrics.md)
-    * [Active DAU Definition](cookbooks/active_dau.md)
-    * [Retention Analysis](cookbooks/retention.md)
+    * [Daily Active Users (DAU)](cookbooks/dau.md)
+    * [Active DAU (aDAU)](cookbooks/active_dau.md)
+    * [Retention](cookbooks/retention.md)
 
 ---
 

--- a/src/cookbooks/dau.md
+++ b/src/cookbooks/dau.md
@@ -45,7 +45,8 @@ ORDER BY
 SELECT
     submission_date AS day,
     cardinality(merge(cast(hll AS HLL))) AS dau
-FROM client_count_daily
+FROM
+    client_count_daily
 WHERE
     -- Limit to 7 days of history
     submission_date >= date_format(CURRENT_DATE - INTERVAL '7' DAY, '%Y%m%d')

--- a/src/cookbooks/dau.md
+++ b/src/cookbooks/dau.md
@@ -1,0 +1,54 @@
+# DAU and MAU
+
+For the purposes of DAU, a profile is considered active if it sends any main ping.
+* Dates are defined by `submission_date_s3`.
+
+**DAU** is the number of clients sending a main ping on a given day.
+
+**MAU** is the number of unique clients who have been a DAU on any day in the last **28 days**. In other words, any client that contributes to DAU in the last 28 days would also contribute to MAU for that day. Note that this is not simply the sum of DAU over 28 days, since any particular client could be active on many days.
+
+For quick analysis, using `clients_daily_v6` is recommended. Below is an example query for getting DAU using `clients_daily_v6`.
+
+```sql
+SELECT
+    submission_date_s3,
+    count(*) AS total_clients_cdv6
+FROM
+    clients_daily_v6
+GROUP BY
+    1
+ORDER BY
+    1 ASC
+```
+
+`main_summary` can also be used for getting DAU. Below is an example query using a 1% sample over March 2018 using `main_summary`:
+
+```sql
+SELECT
+    submission_date_s3,
+    count(DISTINCT client_id) * 100 as DAU
+FROM
+    main_summary
+WHERE
+    sample_id = '51'
+    AND submission_date_s3 >= '20180301'
+    AND submission_date_s3 < '20180401'
+GROUP BY
+    1
+ORDER BY
+    1 ASC
+```
+
+[`client_count_daily`](../datasets/batch_view/client_count_daily/reference.md) can be used to get **approximate** DAU. This dataset uses HyperLogLog to estimate unique counts. For example:
+
+```sql
+SELECT
+    submission_date AS day,
+    cardinality(merge(cast(hll AS HLL))) AS dau
+FROM client_count_daily
+WHERE
+    -- Limit to 7 days of history
+    submission_date >= date_format(CURRENT_DATE - INTERVAL '7' DAY, '%Y%m%d')
+GROUP BY 1
+ORDER BY 1
+```

--- a/src/meta/contributing.md
+++ b/src/meta/contributing.md
@@ -26,7 +26,7 @@ To build the documentation locally, you'll need to install the `mdbook-dtmo` wra
 Binary builds are provided at <https://github.com/badboy/mdbook-dtmo/releases>.
 Download a release for your system, unpack it and place the binary in a directory of your `$PATH`.
 
-If you have [rustc](https://www.rust-lang.org/en-US/) already installed, you can install a pre-compiled binary directly:
+If you have [rustc](https://www.rust-lang.org/) already installed, you can install a pre-compiled binary directly:
 
 ```bash
 curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-dtmo


### PR DESCRIPTION
Added DAU documentation in response to https://bugzilla.mozilla.org/show_bug.cgi?id=1461441 and also cleaned up metric page names as titles for each page in the metrics section are clearest if they are simply names of each metric.