### PR TITLE
Use new home for Airflow

### DIFF
--- a/src/cookbooks/new_ping.md
+++ b/src/cookbooks/new_ping.md
@@ -185,10 +185,13 @@ a [Longitudinal](https://github.com/mozilla/telemetry-batch-view/blob/master/src
 or [client-count-daily](https://github.com/mozilla/telemetry-batch-view/blob/master/src/main/scala/com/mozilla/telemetry/views/GenericCountView.scala)
 like dataset. Otherwise, you'll have to write your own.
 
-You can schedule it on [Airflow](http://workflow.telemetry.mozilla.org/), or you can
+You can schedule it on [Airflow], or you can
 run it as a job in ATMO. If the output is parquet, you can add it to the Hive metastore to have it
 available in re:dash. Check the docs on [creating your own datasets](create_a_dataset.md).
 
 Build Dashboards Using ATMO or STMO
 -----------------------------------
 Last steps! What are you using this data for anyway?
+
+
+[Airflow]: https://r3e51de5feeeb5619-tp.appspot.com/


### PR DESCRIPTION
Unblock link checks. Discussion at https://bugzilla.mozilla.org/show_bug.cgi?id=1519945; @haroldwoo suggested in #datapipeline that this is a stable URL.