### PR TITLE
Mention availability of clients_last_seen outside BigQuery

### DIFF
--- a/src/cookbooks/active_dau.md
+++ b/src/cookbooks/active_dau.md
@@ -12,11 +12,31 @@ An **Active User** is defined as a client who has `total_daily_uri` >= 5 URI for
 
 To make the time boundaries more clear, let's consider a particular date 2019-01-28. The aDAU number assigned to 2019-01-28 should consider all main pings received during 2019-01-28 UTC. We cannot observe the full data until 2019-01-28 closes (and in practice we need to wait a bit longer since we are usually referencing derived datasets like `clients_daily` that are updated once per day over several hours following midnight UTC), so the earliest we can calculate this value is on 2019-01-29. If plotted as a time series, this value should always be plotted at the point labeled 2019-01-28. Likewise, aMAU for 2019-01-28 should consider a 28 day range that includes main pings received on 2019-01-28 and back to beginning of day UTC 2019-01-01. Again, the earliest we can calculate the value is on 2019-01-29.
 
-For quick analysis, using [`clients_last_seen`](../datasets/bigquery/clients_last_seen/reference.md) is recommended, but it is only available in BigQuery. Below is an example query for getting aMAU, aWAU, and aDAU using `clients_last_seen`.
+For quick analysis, using [`firefox_desktop_exact_mau28_by_dimensions`](../datasets/bigquery/exact_mau/reference.md) is recommended. Below is an example query for getting MAU, WAU, and DAU for 2018 using `firefox_desktop_exact_mau28_by_dimensions`.
 
 ```sql
 SELECT
   submission_date,
+  SUM(visited_5_uri_mau) AS visited_5_uri_mau,
+  SUM(visited_5_uri_wau) AS visited_5_uri_wau,
+  SUM(visited_5_uri_dau) AS visited_5_uri_dau
+FROM
+  telemetry.firefox_desktop_exact_mau28_by_dimensions
+WHERE
+  submission_date_s3 >= '2018-01-01'
+  AND submission_date_s3 < '2019-01-01'
+GROUP BY
+  submission_date
+ORDER BY
+  submission_date
+```
+
+For analysis of dimensions not available in `firefox_desktop_exact_mau28_by_dimensions`, using [`clients_last_seen`](../datasets/bigquery/clients_last_seen/reference.md) is recommended. Below is an example query for getting aMAU, aWAU, and aDAU by `app_version` for 2018 using `clients_last_seen`.
+
+```sql
+SELECT
+  submission_date,
+  app_version,
   -- days_since_* values are always < 28 or null, so aMAU could also be
   -- calculated with COUNT(days_since_visited_5_uri)
   COUNTIF(days_since_visited_5_uri < 28) AS visited_5_uri_mau,
@@ -26,13 +46,18 @@ SELECT
   COUNTIF(days_since_visited_5_uri < 1) AS visited_5_uri_dau
 FROM
   telemetry.clients_last_seen
+WHERE
+  submission_date_s3 >= '2018-01-01'
+  AND submission_date_s3 < '2019-01-01'
 GROUP BY
-  submission_date
+  submission_date,
+  app_version
 ORDER BY
-  submission_date ASC
+  submission_date,
+  app_version
 ```
 
-For analysis of only aDAU, using [`clients_daily`](../datasets/batch_view/clients_daily/reference.md) is more efficient than `clients_last_seen`. Getting aMAU and aWAU from `clients_daily` is not recommended. Below is an example query for getting aDAU using `clients_daily`.
+For analysis of only aDAU, using [`clients_daily`](../datasets/batch_view/clients_daily/reference.md) is more efficient than `clients_last_seen`. Getting aMAU and aWAU from `clients_daily` is not recommended. Below is an example query for getting aDAU for 2018 using `clients_daily`.
 
 ```sql
 SELECT
@@ -42,10 +67,13 @@ FROM
   telemetry.clients_daily
 WHERE
   scalar_parent_browser_engagement_total_uri_count_sum >= 5
+  -- In BigQuery use yyyy-MM-DD, e.g. '2018-01-01'
+  AND submission_date_s3 >= '20180101'
+  AND submission_date_s3 < '20190101'
 GROUP BY
   submission_date_s3
 ORDER BY
-  submission_date_s3 ASC
+  submission_date_s3
 ```
 
 [`main_summary`](../datasets/batch_view/main_summary/reference.md) can also be used for getting aDAU. Below is an example query using a 1% sample over March 2018 using `main_summary`:
@@ -74,7 +102,7 @@ WHERE
 GROUP BY
   submission_date_s3
 ORDER BY
-  submission_date_s3 ASC
+  submission_date_s3
 ```
 
 <span id="total_uri_count">**1**</span>: Note, the probe measuring `scalar_parent_browser_engagement_total_uri_count` only exists in clients with Firefox 50 and up. Clients on earlier versions of Firefox won't be counted as an Active User (regardless of their use). Similarly, `scalar_parent_browser_engagement_total_uri_count` doesn't increment when a client is in Private Browsing mode, so that won't be included as well.

--- a/src/datasets/bigquery/clients_last_seen/intro.md
+++ b/src/datasets/bigquery/clients_last_seen/intro.md
@@ -6,8 +6,7 @@ It does *not* use approximates, unlike the HyperLogLog algorithm used in the
 and it includes the most recent values in a 28 day window for all columns in
 the [`clients_daily` dataset](/datasets/batch_view/clients_daily/reference.md).
 
-This dataset should be used instead of `client_count_daily` in BigQuery,
-and is not currently available outside of BigQuery.
+This dataset should be used instead of `client_count_daily`.
 
 #### Content
 

--- a/src/datasets/bigquery/clients_last_seen/reference.md
+++ b/src/datasets/bigquery/clients_last_seen/reference.md
@@ -58,9 +58,9 @@ ORDER BY
 ## Scheduling
 
 This dataset is updated daily via the
-[parquet to BigQuery](https://github.com/mozilla-services/spark-parquet-to-bigquery)
+[telemetry-airflow](https://github.com/mozilla/telemetry-airflow)
 infrastructure. The job runs as part of the
-[`reprocess_clients_daily_v6` DAG](https://github.com/mozilla-services/spark-parquet-to-bigquery/blob/master/dags/reprocess_clients_daily_v6.py).
+[`main_summary` DAG](https://github.com/mozilla/telemetry-airflow/blob/89a6dc3/dags/main_summary.py#L365).
 
 ## Schema
 

--- a/src/tools/stmo.md
+++ b/src/tools/stmo.md
@@ -91,47 +91,47 @@ query editing page:
 ![New Query Page](../assets/STMO_screenshots/new_query.png "New Query page")
 
 For this (and most queries where we're counting distinct client IDs) we'll want
-to use the [`clients_last_seen` data
-set](../datasets/bigquery/clients_last_seen/reference.md) that is generated from
-Firefox telemetry pings.
+to use
+[`clients_last_seen`](../datasets/bigquery/clients_last_seen/reference.md),
+which is generated from Firefox telemetry pings.
 
-* Check if the data set is in BigQuery
+* Check if the table is in BigQuery
 
   As mentioned above, BigQuery is replacing Athena and Presto, but not all data
   sets are yet available in BigQuery. Click on the 'Data Source' drop-down and
   select BigQuery, then check to see if the one we want is available by typing
   `clients_last_seen` into the "Search schema..." search box above the schema
   browser interface to the left of the main query edit box. You should see that
-  there is, in fact, a `clients_last_seen` data set (showing up as
+  there is, in fact, a `clients_last_seen` table (showing up as
   `telemetry.clients_last_seen`), as well as versioned `clients_last_seen` data
   sets (showing up as `telemetry.clients_last_seen_v<VERSION>`).
 
-* Check if the data set is in Athena
+* Check if the table is in Athena
 
   If it's not in BigQuery, now we should check to see if it's in Athena. If you
   click on the 'Data Source' drop-down and change the selection from 'BigQuery'
   to 'Athena' (with `clients_last_seen` still populating the filter input), you
-  should see that there are no matches for `clients_last_seen`, which means
-  this data set is not available in *Athena*.
+  should see that there is a match for `clients_last_seen`, which means this
+  table is available in *Athena*.
 
-* Check if the data set is in Presto
+* Check if the table is in Presto
 
   If it's also not in Athena, now we should check to see if it's in Presto. If
   you click on the 'Data Source' drop-down and change the selection from
   'Athena' to 'Presto' (with `clients_last_seen` still populating the filter
-  input), you should see that there are no matches for `clients_last_seen`,
-  which means this data set is not available in *Presto* either.
+  input), you should see that there is a match for `clients_last_seen`, which
+  means this table is available in *Presto*.
 
 * Introspect the available columns
 
   Click on the 'Data Source' drop-down and change the selection to 'BigQuery',
   and click on `telemetry.clients_last_seen` in the schema browser to expose
-  the columns that are available in the data set. Three of the columns are of
+  the columns that are available in the table. Three of the columns are of
   interest to us for this query: `country`, `days_since_seen`, and
   `submission_date`.
 
-So a query that extracts all of the unique country values and the most recent
-MAU for each one, sorted from highest MAU to lowest MAU looks like this:
+So a query that extracts all of the unique country values and the MAU for one
+day for each one, sorted from highest MAU to lowest MAU looks like this:
 
 ```sql
 SELECT
@@ -140,7 +140,7 @@ SELECT
 FROM
   telemetry.clients_last_seen
 WHERE
-  submission_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+  submission_date = '2019-04-01'
 GROUP BY
   country
 ORDER BY
@@ -199,7 +199,7 @@ SELECT
 FROM
   telemetry.clients_last_seen
 WHERE
-  submission_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+  submission_date = '2019-04-01'
 GROUP BY
   country
 ORDER BY
@@ -210,7 +210,7 @@ LIMIT
 
 If you edit the query to add a limit clause and again hit the 'Execute' button,
 you should get a new bar graph that only shows the 20 countries with the
-highest number of unique clients. In this case, the full data set has
+highest number of unique clients. In this case, the full result set has
 approximately 250 return values, and so limiting the result count improves
 readability. In other cases, however, an unlimited query might return thousands
 or even millions of rows. When those queries are run, readability is not the
@@ -221,7 +221,7 @@ of the other users of the system. Thus, a very important warning:
   **ALL QUERIES SHOULD INCLUDE A "LIMIT" STATEMENT BY DEFAULT!**
 
 You should be in the habit of adding a "LIMIT 100" clause to the end of all new
-queries, to prevent your query from returning a gigantic data set that causes
+queries, to prevent your query from returning a gigantic result set that causes
 UI and performance problems. You may learn that the total result set is small
 enough that the limit is unnecessary, but unless you're certain that is the
 case specifying an explicit LIMIT helps prevent unnecessary issues.
@@ -244,7 +244,7 @@ SELECT
 FROM
   telemetry.clients_last_seen
 WHERE
-  submission_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+  submission_date = '2019-04-01'
 GROUP BY
   country
 ORDER BY
@@ -304,7 +304,7 @@ SELECT
 FROM
   telemetry.clients_last_seen
 WHERE
-  submission_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+  submission_date = '2019-04-01'
 GROUP BY
   os
 ORDER BY
@@ -322,7 +322,7 @@ SELECT
 FROM
   telemetry.clients_last_seen
 WHERE
-  submission_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+  submission_date = '2019-04-01'
 GROUP BY
   channel
 ORDER BY
@@ -339,7 +339,7 @@ SELECT
 FROM
   telemetry.clients_last_seen
 WHERE
-  submission_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 DAY)
+  submission_date = '2019-04-01'
 GROUP BY
   app_name,
   app_version


### PR DESCRIPTION
also included:

- use partition filters in example DAU and aDAU queries so that they don't break when those become required
- removed redundant and inconsistent `ASC` from `ORDER BY` clauses in example DAU and aDAU queries
- refer to exact mau tables as preferred source of DAU and aDAU analysis, before falling back to `clients_last_seen`
- indicate `table` or `result set` instead of `data set` in stmo doc, to prevent confusion with the BigQuery term `dataset`
- update queries in touched files to be compatible with both Athena and BigQuery, where possible.