### PR TITLE
Use latest available mdbook & extension releases

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -122,6 +122,7 @@ matcher
 matchers
 MAU
 mdbook
+mdbook-toc
 Melancon
 metadata
 metastore
@@ -165,6 +166,7 @@ pre-processes
 pre-release
 pre-released
 pre-specified
+preprocessors
 Prefs
 prefs
 prepended

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,14 @@ addons:
       - parallel
 install:
   - npm install markdown-spellcheck markdown-link-check -g
-  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-dtmo
+  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git rust-lang-nursery/mdBook
+  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-toc
+  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-mermaid
 script:
-  - mdbook-dtmo --version
-  - mdbook-dtmo build .
+  - mdbook --version
+  - mdbook-toc --version
+  - mdbook-mermaid --version
+  - mdbook build .
   - mdspell 'src/**/*.md' --ignore-numbers --en-us --report
   - bash scripts/link_check.sh
 deploy:

--- a/book.toml
+++ b/book.toml
@@ -4,6 +4,13 @@ title = "Firefox Data Documentation"
 [build]
 create-missing = false
 
+[preprocessor.mermaid]
+command = "mdbook-mermaid"
+renderer = ["html"]
+
+[preprocessor.toc]
+command = "mdbook-toc"
+
 [output.html]
 additional-css = ["dtmo.css", "mermaid.css"]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@
 build_dir='book'
 
 # Depends on https://github.com/davisp/ghp-import
-mdbook-dtmo build . --dest-dir $build_dir && \
+mdbook build . --dest-dir $build_dir && \
 touch $build_dir/.nojekyll && \
 ghp-import \
     -b gh-pages \

--- a/src/meta/contributing.md
+++ b/src/meta/contributing.md
@@ -22,28 +22,34 @@ To begin contributing to the docs, fork the `firefox-data-docs` repo.
 
 The documentation is rendered with [mdBook](https://github.com/rust-lang-nursery/mdBook).
 
-To build the documentation locally, you'll need to install the `mdbook-dtmo` wrapper.
-Binary builds are provided at <https://github.com/badboy/mdbook-dtmo/releases>.
-Download a release for your system, unpack it and place the binary in a directory of your `$PATH`.
+To build the documentation locally, you'll need additional preprocessors:
+
+* [mdbook-toc](https://github.com/badboy/mdbook-toc/releases)
+* [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid/releases)
+
+Download releases for your system, unpack it and place the binary in a directory of your `$PATH`.
 
 If you have [rustc](https://www.rust-lang.org/) already installed, you can install a pre-compiled binary directly:
 
 ```bash
-curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-dtmo
+curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-toc
+curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-mermaid
 ```
 
-This will place `mdbook-dtmo` into `~/.cargo/bin`. Make sure this directory is in your `$PATH` or copy it to a directory of your `$PATH`.
+This will place `mdbook-toc` and `mdbook-mermaid` into `~/.cargo/bin`.
+Make sure this directory is in your `$PATH` or copy it to a directory of your `$PATH`.
 
-You can also build and install `mdbook-dtmo`:
+You can also build and install the preprocessors:
 
 ```bash
-cargo install --git https://github.com/badboy/mdbook-dtmo
+cargo install mdbook-toc
+cargo install mdbook-mermaid
 ```
 
 You can then serve the documentation locally with:
 
 ```
-mdbook-dtmo serve
+mdbook serve
 ```
 
 The complete documentation for the mdBook toolchain is available online at <https://rust-lang-nursery.github.io/mdBook/>.


### PR DESCRIPTION
mdbook got several updates since we based this book on a fork.
It's now possible to use external preprocessors and both preprocessors
we use are now available as binary releases managed by me.