### PR TITLE
Real-time analysis plugins depend on the AWS stack

### DIFF
--- a/src/cookbooks/realtime_analysis_plugin.md
+++ b/src/cookbooks/realtime_analysis_plugin.md
@@ -1,5 +1,10 @@
 # Creating a Real-time Analysis Plugin
 
+> This technique relies on the AWS ingestion pipeline.
+In [BigQuery](bigquery.md), the tables in the `moz-fx-data-shared-prod:telemetry_live` dataset
+have only a few minutes of latency, so you can query those from STMO or the BigQuery console
+for near real-time data access instead of writing an analysis plugin.
+
 ## Getting Started
 
 Creating an analysis plugin consists of three steps:

--- a/src/cookbooks/view_pings_cep.md
+++ b/src/cookbooks/view_pings_cep.md
@@ -1,5 +1,10 @@
 # See My Pings
 
+> This technique relies on the AWS ingestion pipeline.
+In [BigQuery](bigquery.md), the tables in the `moz-fx-data-shared-prod:telemetry_live` dataset
+have only a few minutes of latency, so you can query those tables for pings from your `client_id`
+using STMO or the BigQuery console instead of writing an analysis plugin.
+
 So you want to see what you're sending the telemetry pipeline, huh? Well follow these steps and we'll have you reading some JSON in no time.
 
 For a more thorough introduction, see [Creating a Real-Time Analysis Plugin Cookbook](realtime_analysis_plugin.md).

--- a/src/tools/cep_matcher.md
+++ b/src/tools/cep_matcher.md
@@ -1,6 +1,11 @@
 CEP Matcher
 ===========
 
+> This technique relies on the AWS ingestion pipeline.
+In [BigQuery](../cookbooks/bigquery.md), the tables in the `moz-fx-data-shared-prod:telemetry_live` dataset
+have only a few minutes of latency, so you can query those from STMO or the BigQuery console
+for near real-time data access instead of writing an analysis plugin.
+
 The CEP Matcher tab lets you easily view some current pings of any ping type. To access it, follow
 [these first few directions](../cookbooks/realtime_analysis_plugin.md) for accessing the CEP. Once there,
 click on the "Matcher" tab. The message-matcher is set by default to `TRUE`, meaning all pings will


### PR DESCRIPTION
Point to the _live datasets as alternatives.