### PR TITLE
Add two more gotchas.

### DIFF
--- a/.linkcheck.json
+++ b/.linkcheck.json
@@ -7,6 +7,7 @@
         { "pattern": "^https://github.com/mozilla-services/spark-parquet-to-bigquery" },
         { "pattern": "^https://github.com/mozilla/Fx-Data-Planning" },
         { "pattern": "^https://sql.telemetry.mozilla.org" },
-        { "pattern": "^https://github.com/mozilla/stmo_core_product_metrics" }
+        { "pattern": "^https://github.com/mozilla/stmo_core_product_metrics" },
+        { "pattern": "^https://github.com/mozilla-services/cloudops-infra" }
     ]
 }

--- a/src/concepts/analysis_gotchas.md
+++ b/src/concepts/analysis_gotchas.md
@@ -8,10 +8,12 @@ This document is not about those traps. Instead, it is about quirks and pitfalls
 
 When looking at trends, it is helpful to be aware of events from the past that might impact comparisons with history. Here are a few to keep in mind:
 
+- **September 1 - October 18 2019** - BigQuery Ping tables are [missing the `X-PingSender-Version` header information](https://github.com/mozilla-services/cloudops-infra/pull/1491). This data is available before and after this time period.
 - **May 4 - May 11 2019** - [Telemetry source data deleted](https://blog.mozilla.org/blog/2019/05/09/what-we-do-when-things-go-wrong/). No source data is available for this period and derived tables may have missing days or imputed values. Derived tables that depend on multiple days may have have affected dates beyond the deletion region.
 - **January 31 2019** - [Profile-per-install](https://bugzilla.mozilla.org/show_bug.cgi?id=1474285) landed in `mozilla-central` and affects how new profiles are created. See [discussion in `bigquery-etl#212`](https://github.com/mozilla/bigquery-etl/issues/212).
 - **October 25 2018** - many `client_id`s on Firefox Android were reset to the same `client_id`.  For more information see the blameless post-mortem document [here](https://docs.google.com/document/d/1r1PDQnqhsrPkft0pB46v9uhXGxR_FzK4laKJLGttXdA) or [bug 1501329](https://bugzilla.mozilla.org/show_bug.cgi?id=1501329).
 - **November 2017** - Quantum Launch. There was a surge in new profiles and usage.
+- **June 1 and 5, 2016** - [Main Summary `v4` data is missing](https://bugzilla.mozilla.org/show_bug.cgi?id=1482509) for these two days.
 - **March 2016** - Unified Telemetry launched.
 
 ### Pseudo-replication


### PR DESCRIPTION
The missing `X-PingSender-Version` was discovered as part of data validation ahead of backfill. The other one happened to be top-of-mind while I was editing.