### PR TITLE
There can be only one!

### DIFF
--- a/src/concepts/glean/glean.md
+++ b/src/concepts/glean/glean.md
@@ -63,9 +63,7 @@ To make it easier to understand the general semantics of our data, the Glean SDK
 
 # References
 
-* There currently two independent implementations of the Glean SDK:
-  * An Android-only implementation in [android-components](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean).
-  * A [cross-platform implementation](https://github.com/mozilla/glean/). (This implementation is currently under development and not ready for use).
-*   [Reporting issues & bugs for the Glean SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=Glean%3A%20SDK).
-*   Datasets documentation (TBD)
-*   [Glean Debug pings viewer](https://debug-ping-preview.firebaseapp.com/)
+* The [cross-platform implementation](https://github.com/mozilla/glean/)
+* [Reporting issues & bugs for the Glean SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=Glean%3A%20SDK).
+* Datasets documentation (TBD)
+* [Glean Debug pings viewer](https://debug-ping-preview.firebaseapp.com/)

--- a/src/concepts/glean/glean.md
+++ b/src/concepts/glean/glean.md
@@ -63,7 +63,7 @@ To make it easier to understand the general semantics of our data, the Glean SDK
 
 # References
 
-* The [cross-platform implementation](https://github.com/mozilla/glean/)
+* The [Glean SDK](https://github.com/mozilla/glean/) implementation.
 * [Reporting issues & bugs for the Glean SDK](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=Glean%3A%20SDK).
 * Datasets documentation (TBD)
 * [Glean Debug pings viewer](https://debug-ping-preview.firebaseapp.com/)


### PR DESCRIPTION
The android-components Kotlin glean was replaced with the Rust glean:
https://github.com/mozilla-mobile/android-components/commit/12163f1f313e0ecbde9ca2abae1cd7b4a4ce9704

@dexterp37, did I get this right?