### PR TITLE
Change repository to fetch mdBook from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
       - parallel
 install:
   - npm install markdown-spellcheck markdown-link-check -g
-  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git rust-lang-nursery/mdBook
+  - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git rust-lang/mdBook
   - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-toc
   - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-mermaid
 script:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Linux Build Status](https://travis-ci.org/mozilla/firefox-data-docs.svg?branch=master)](https://travis-ci.org/mozilla/firefox-data-docs)
 
-This document is intended to help Mozilla's developers and data scientists analyze and interpret the data gathered 
+This document is intended to help Mozilla's developers and data scientists analyze and interpret the data gathered
 by the Firefox Telemetry system.
 
 At [Mozilla](https://www.mozilla.org), our data-gathering and data-handling practices are anchored in our
@@ -10,10 +10,10 @@ At [Mozilla](https://www.mozilla.org), our data-gathering and data-handling prac
 [Mozilla Privacy Policy](https://www.mozilla.org/en-US/privacy/).
 
 To learn more about what data Firefox collects and the choices you can make as a user, please see the
-[Firefox Privacy Notice](https://www.mozilla.org/en-US/privacy/firefox/). 
+[Firefox Privacy Notice](https://www.mozilla.org/en-US/privacy/firefox/).
 
 You can find the [rendered documentation here](https://mozilla.github.io/firefox-data-docs/).
 
-This documentation is rendered with [mdBook](https://github.com/rust-lang-nursery/mdBook).
+This documentation is rendered with [mdBook](https://github.com/rust-lang/mdBook).
 
 To contribute to the docs, see [this article](src/meta/contributing.md).

--- a/src/concepts/pipeline/event_pipeline.md
+++ b/src/concepts/pipeline/event_pipeline.md
@@ -9,7 +9,6 @@ graph TD
 subgraph Products
 fx_code(fa:fa-cog Firefox code) --> firefox(fa:fa-firefox Firefox Telemetry)
 fx_extensions(fa:fa-cog Mozilla extensions) --> firefox
-fx_hybrid(fa:fa-cog Hybrid Content) --> firefox
 mobile(fa:fa-cog Mobile products) --> mobile_telemetry(fa:fa-firefox Mobile Telemetry)
 end
 
@@ -32,7 +31,6 @@ end
 
 style fx_code fill:#f94,stroke-width:0px
 style fx_extensions fill:#f94,stroke-width:0px
-style fx_hybrid fill:#f94,stroke-width:0px
 style mobile fill:#f94,stroke-width:0px
 style firefox fill:#f61,stroke-width:0px
 style mobile_telemetry fill:#f61,stroke-width:0px
@@ -101,8 +99,6 @@ use cases:
   code.
 - The *[Telemetry WebExtension API](https://searchfox.org/mozilla-central/rev/55da592d85c2baf8d8818010c41d9738c97013d2/toolkit/components/extensions/schemas/telemetry.json#87)* ([introduced here](https://bugzilla.mozilla.org/show_bug.cgi?id=1280234))
   which allows Mozilla extensions to record new events into Telemetry.
-- The [*Hybrid-content API*](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/hybrid-content.html)
-  allows specific white-listed Mozilla content code to record new events into Telemetry.
 
 For all these APIs, events will get sent to the pipeline through the
 [event ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/event-ping.html), which gets sent hourly, if any pings were recorded, or up to every 10 minutes whenever 1000 events were recorded.

--- a/src/datasets/obsolete/client_count_daily/intro.md
+++ b/src/datasets/obsolete/client_count_daily/intro.md
@@ -1,5 +1,5 @@
 The `client_count_daily` dataset is useful for estimating user counts over a few
-[pre-defined dimensions](https://github.com/mozilla/telemetry-airflow/blob/master/jobs/client_count_daily_view.sh).
+[pre-defined dimensions][client_count_daily_view.sh].
 
 The `client_count_daily` dataset is similar to the deprecated
 [`client_count` dataset](/datasets/batch_view/client_count/reference.md)
@@ -12,7 +12,7 @@ The `hll` column contains a
 [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog)
 variable, which is an approximation to the exact count.
 The factor columns include **submission** date and the dimensions listed
-[here](https://github.com/mozilla/telemetry-airflow/blob/master/jobs/client_count_daily_view.sh).
+[here][client_count_daily_view.sh].
 Each row represents one combinations of the factor columns.
 
 #### Background and Caveats
@@ -37,3 +37,5 @@ Take a look at this
 I don't recommend accessing this data from ATMO.
 
 #### Further Reading
+
+[client_count_daily_view.sh]: https://github.com/mozilla/telemetry-airflow/blob/adfce4a30895faa607ccf586b292b61ad68d8f75/jobs/client_count_daily_view.sh

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,15 +1,15 @@
 # Firefox Data Documentation
 
-This documentation is intended to help Mozilla's developers and data scientists analyze and interpret the data gathered 
-by the Firefox Telemetry system. 
+This documentation is intended to help Mozilla's developers and data scientists analyze and interpret the data gathered
+by the Firefox Telemetry system.
 
 At [Mozilla](https://www.mozilla.org), our data-gathering and data-handling practices are anchored in our
 [Data Privacy Principles](https://www.mozilla.org/en-US/privacy/principles/) and elaborated in the
 [Mozilla Privacy Policy](https://www.mozilla.org/en-US/privacy/). You can learn more about what data Firefox
-collects and the choices you can make as a Firefox user in the 
-[Firefox Privacy Notice](https://www.mozilla.org/en-US/privacy/firefox/). 
+collects and the choices you can make as a Firefox user in the
+[Firefox Privacy Notice](https://www.mozilla.org/en-US/privacy/firefox/).
 
-If there's information missing from these docs, or if you'd like to contribute, see [this article on contributing](meta/contributing.md), 
+If there's information missing from these docs, or if you'd like to contribute, see [this article on contributing](meta/contributing.md),
 and feel free to [file a bug here](https://bugzilla.mozilla.org/enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&component=Documentation%20and%20Knowledge%20Repo%20%28RTMO%29&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&defined_groups=1&flag_type-4=X&flag_type-607=X&flag_type-800=X&flag_type-803=X&flag_type-916=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Linux&priority=--&product=Data%20Platform%20and%20Tools&rep_platform=x86_64&target_milestone=---&version=unspecified).
 
 The source for this documentation can be found in [this repo](https://github.com/mozilla/firefox-data-docs).
@@ -37,6 +37,6 @@ This documentation is divided into four main sections:
   You do not need to read this section end-to-end.
 
 You can find the [fully-rendered documentation here](https://mozilla.github.io/firefox-data-docs/),
-rendered with [mdBook](https://github.com/rust-lang-nursery/mdBook), and hosted on Github pages.
+rendered with [mdBook](https://github.com/rust-lang/mdBook), and hosted on Github pages.
 
 

--- a/src/meta/contributing.md
+++ b/src/meta/contributing.md
@@ -20,7 +20,7 @@ To begin contributing to the docs, fork the `firefox-data-docs` repo.
 
 ## Building the Documentation
 
-The documentation is rendered with [mdBook](https://github.com/rust-lang-nursery/mdBook).
+The documentation is rendered with [mdBook](https://github.com/rust-lang/mdBook).
 
 To build the documentation locally, you'll need additional preprocessors:
 
@@ -52,7 +52,7 @@ You can then serve the documentation locally with:
 mdbook serve
 ```
 
-The complete documentation for the mdBook toolchain is available online at <https://rust-lang-nursery.github.io/mdBook/>.
+The complete documentation for the mdBook toolchain is available online at <https://rust-lang.github.io/mdBook/>.
 If you run into any technical limitations, let `@harterrt` or `@badboy` know.
 We are happy to change the tooling to make it as much fun as possible to write.
 


### PR DESCRIPTION
The nursery was recently deprecated and mdBook was moved to the main
organisation:
https://internals.rust-lang.org/t/rust-lang-nursery-deprecation/11205/2