### PR TITLE
Fix various broken API references

### DIFF
--- a/src/concepts/pipeline/data_pipeline.md
+++ b/src/concepts/pipeline/data_pipeline.md
@@ -199,7 +199,7 @@ There is a vast ecosystem of tools for processing data at scale, each with their
 [dump data directly in Parquet form]: https://github.com/mozilla-services/lua_sandbox_extensions/pull/48
 [private repository]: https://github.com/mozilla-services/puppet-config/tree/02f716a3e0df1117fc2494b41e85a1416f8e2a64/pipeline
 [ATMO]: https://analysis.telemetry.mozilla.org/
-[an API]: https://python-moztelemetry.readthedocs.io/en/stable/api.html#module-moztelemetry.dataset
+[an API]: https://mozilla.github.io/python_moztelemetry/api.html#module-moztelemetry.dataset
 [EMR]: https://github.com/mozilla/emr-bootstrap-spark/
 [ETL jobs]: https://github.com/mozilla/telemetry-batch-view
 [Airflow]: https://github.com/mozilla/telemetry-airflow/

--- a/src/concepts/pipeline/data_pipeline_detail.md
+++ b/src/concepts/pipeline/data_pipeline_detail.md
@@ -420,7 +420,7 @@ graph LR
 [Telemetry Aggregates]: https://github.com/mozilla/python_mozaggregator/#api
 [Amazon S3]: https://aws.amazon.com/s3/
 [TAAR Project]: https://github.com/mozilla/python_mozetl/blob/master/mozetl/taar/taar_dynamo.py
-[py_dataset]: https://python-moztelemetry.readthedocs.io/en/latest/api.html#dataset
+[py_dataset]: https://mozilla.github.io/python_moztelemetry/api.html#dataset
 [moztelemetry]: https://github.com/mozilla/moztelemetry/blob/master/src/main/scala/com/mozilla/telemetry/heka/Dataset.scala
 [statsd]: https://github.com/etsy/statsd
 [hslog]: https://mozilla-services.github.io/lua_sandbox_extensions/moz_logging/

--- a/src/datasets/batch_view/sync_summary/reference.md
+++ b/src/datasets/batch_view/sync_summary/reference.md
@@ -85,7 +85,7 @@ Sadly, these datasets are not sampled. It should be possible to derive a `sample
 
 This dataset is updated daily, shortly after midnight UTC.
 The job is scheduled on [Airflow](https://github.com/mozilla/telemetry-airflow).
-The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/master/dags/sync_view.py).
+The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/27d34a73db02131a39f469f3950c1da747bc8a95/dags/sync_view.py).
 
 ## Sync Summary Schema
 

--- a/src/datasets/heartbeat.md
+++ b/src/datasets/heartbeat.md
@@ -89,4 +89,4 @@ telemetry_heartbeat_parquet
 
 [heartbeat]: https://docs.telemetry.mozilla.org/tools/experiments.html#heartbeat
 [hbping]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/heartbeat-ping.html
-[show-heartbeat]: https://normandy.readthedocs.io/user/actions/show-heartbeat.html
+[show-heartbeat]: https://mozilla.github.io/normandy/user/actions/show-heartbeat.html

--- a/src/datasets/ping_intro.md
+++ b/src/datasets/ping_intro.md
@@ -155,7 +155,7 @@ To augment our data collection, see [Collecting New Data][addprobe] and the
 [preferences]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/internals/preferences.html
 [atmo]: https://analysis.telemetry.mozilla.org/
 [stmo]: https://sql.telemetry.mozilla.org/
-[dataset]: https://python-moztelemetry.readthedocs.io/en/stable/api.html#module-moztelemetry.dataset
+[dataset]: https://mozilla.github.io/python_moztelemetry/api.html#module-moztelemetry.dataset
 [addprobe]: https://developer.mozilla.org/en-US/docs/Mozilla/Performance/Adding_a_new_Telemetry_probe
 [datacollection]: https://wiki.mozilla.org/Firefox/Data_Collection
 [pingsender]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/internals/pingsender.html

--- a/src/datasets/pings.md
+++ b/src/datasets/pings.md
@@ -18,7 +18,7 @@ information about the ingestion environment, including timestamps;
 Geo-IP data about the client;
 and fields extracted from the ping or client headers that are useful for downstream processing.
 
-The [Dataset API](https://python-moztelemetry.readthedocs.io/en/latest/api.html#dataset)
+The [Dataset API](https://mozilla.github.io/python_moztelemetry/api.html#dataset)
 represents this metadata by appending a `meta` key to the ping body.
 These fields may also be available as members of a `metadata` struct column
 in direct-to-parquet datasets.

--- a/src/datasets/shield.md
+++ b/src/datasets/shield.md
@@ -134,7 +134,7 @@ data latency should be less than 1 hour.
 The `telemetry-cohorts` dataset contains a subset of pings
 from clients enrolled in experiments,
 accessible as a
-[Dataset](https://python-moztelemetry.readthedocs.io/en/stable/api.html#dataset),
+[Dataset](https://mozilla.github.io/python_moztelemetry/api.html#dataset),
 and partitioned by `experimentId` and `docType`.
 
 Experiments deployed to large fractions of the release channel


### PR DESCRIPTION
Some readthedocs redirection we were formerly relying on is broken for moztelemetry and normandy (we have since moved the docs to our github account). In the case of moztelemetry, we should just remove any record of this API's existence, but this will hopefully fix the build at least.

There was also a link to the sync job definition in airflow which referenced master.