### PR TITLE
Don't check google docs links

### DIFF
--- a/.linkcheck.json
+++ b/.linkcheck.json
@@ -9,6 +9,7 @@
         { "pattern": "^https://sql.telemetry.mozilla.org" },
         { "pattern": "^https://github.com/mozilla/stmo_core_product_metrics" },
         { "pattern": "^https://github.com/mozilla-services/cloudops-infra" },
-        { "pattern": "^https://analysis.telemetry.mozilla.org" }
+        { "pattern": "^https://analysis.telemetry.mozilla.org" },
+        { "pattern": "^https://docs.google.com" }
     ]
 }


### PR DESCRIPTION
It seems like link checks against google docs are timing out. In general it's probably
not great practice to link against these kind of ephemeral resources, but in the
meanwhile this fixes builds.