### PR TITLE
Fix dead links.

### DIFF
--- a/src/datasets/batch_view/crash_summary/reference.md
+++ b/src/datasets/batch_view/crash_summary/reference.md
@@ -31,7 +31,7 @@ submitted by Firefox.
 This dataset is updated daily, shortly after midnight UTC.
 The job is scheduled on
 [telemetry-airflow](https://github.com/mozilla/telemetry-airflow).
-The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/master/dags/crash_summary.py).
+The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/166e0a555ee2de0d3c7f0add1011f7771f7ea23d/dags/crash_summary.py).
 
 ## Schema
 

--- a/src/datasets/batch_view/longitudinal/reference.md
+++ b/src/datasets/batch_view/longitudinal/reference.md
@@ -41,7 +41,7 @@ you can recreate this sample by doing this filter manually.
 
 The `longitudinal` job is run weekly, early on Sunday morning UTC.
 The job is scheduled on [Airflow](https://github.com/mozilla/telemetry-airflow).
-The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/master/dags/longitudinal.py).
+The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/54cffc42a2ca24e46056b7030735f0d4d093c0c7/dags/longitudinal.py).
 
 ## Schema
 

--- a/src/datasets/batch_view/telemetry_aggregates/reference.md
+++ b/src/datasets/batch_view/telemetry_aggregates/reference.md
@@ -49,7 +49,7 @@ We ignore invalid pings in our processing. Invalid pings are defined as those th
 
 The `telemetry_aggregates` job is run daily, at midnight UTC.
 The job is scheduled on [Airflow](https://github.com/mozilla/telemetry-airflow).
-The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/master/dags/mozaggregator_parquet.py)
+The DAG is [here](https://github.com/mozilla/telemetry-airflow/blob/831fe84a36347f440ede4f5a90e0bf83d4fa1e1e/dags/mozaggregator_parquet.py)
 
 ## Schema
 

--- a/src/datasets/fxa.md
+++ b/src/datasets/fxa.md
@@ -36,7 +36,9 @@ One more thing: China runs its own stack for sync, but Chinese sign-ups for oaut
 
 Unlike most telemetry described in these docs, FxA metrics are logged server-side. There are many [FxA "servers"](https://github.com/mozilla/fxa/tree/master/packages) that handle different aspects of account authentication and management. The metrics of most interest to data analysts are logged by the FxA auth server, content server and oauth server. Each server writes their metrics into their log stream, and some post-processing scripts combine the metrics events from all three servers into datasets that are available in Databricks, BigQuery, STMO and Amplitude.
 
-In general, metrics logged by the [FxA auth server](https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-server) reflect authentication events such as account creation, logins to existing accounts, etc. Metrics logged by the [FxA content server](https://github.com/mozilla/fxa/tree/master/packages/fxa-content-server) reflect user interaction and progression through the FxA web UI - form views, form engagement, form submission, etc. The [FxA oauth server](https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-server/fxa-oauth-server) logs metrics events when oauth clients (Monitor, Lockwise, etc) create and check authentication tokens.
+In general, metrics logged by the [FxA auth server](https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-server) reflect authentication events such as account creation, logins to existing accounts, etc.
+Metrics logged by the [FxA content server](https://github.com/mozilla/fxa/tree/master/packages/fxa-content-server) reflect user interaction and progression through the FxA web UI - form views, form engagement, form submission, etc.
+The [FxA oauth server](https://github.com/mozilla/fxa/pull/3176) logs metrics events when oauth clients (Monitor, Lockwise, etc) create and check authentication tokens.
 
 ## Metrics Taxonomies
 


### PR DESCRIPTION
The fxa "oauth-server" link now points to the commit in which that code
was removed. The others point to specific revisions of the referenced file.