### PR TITLE
Reformat "how to use" section for proper rendering"

### DIFF
--- a/src/concepts/glean/glean.md
+++ b/src/concepts/glean/glean.md
@@ -44,25 +44,28 @@ To make it easier to understand the general semantics of our data, the Glean SDK
 
 # How to use Glean
 
-*   [Integrate the Glean SDK / library](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project.html) into your product.
-*   [File a data engineering bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=General&short_desc=Glean:%20Enable%20application%20id%20org.mozilla.myProduct) to enable your products application id.
-*   [Use Redash](https://sql.telemetry.mozilla.org/) to write SQL queries & build dashboards using your products datasets, e.g.:
-    *   `org_mozilla_fenix.baseline`
-    *   `org_mozilla_fenix.events`
-    *   `org_mozilla_fenix.metrics`
-    *   Example query: ```
--- Count unique Client IDs observed on a given day
-SELECT
-  count(distinct client_info.client_id)
-FROM
-  org_mozilla_fenix.baseline
-WHERE
-  date(submission_timestamp) = '2019-11-11'
-```
-*   _(Work in progress)_ Use events and [Amplitude](https://sso.mozilla.com/amplitude) for product analytics.
-*   [Use Databricks](https://sso.mozilla.com/databricks) for deep-dive analysis.
-*   [Use the Glean debug ping viewer](debug_ping_view.md) for QA & development.
-*   For experimentation, you will be able to use [Android experiments library](https://github.com/mozilla-mobile/android-components/blob/master/components/service/experiments/README.md), which integrates with Glean.
+* [Integrate the Glean SDK / library](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project.html) into your product.
+* [File a data engineering bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Data%20Platform%20and%20Tools&component=General&short_desc=Glean:%20Enable%20application%20id%20org.mozilla.myProduct) to enable your products application id.
+* [Use Redash](https://sql.telemetry.mozilla.org/) to write SQL queries & build dashboards using your products datasets, e.g.:
+  * `org_mozilla_fenix.baseline`
+  * `org_mozilla_fenix.events`
+  * `org_mozilla_fenix.metrics`
+  * Example query:
+
+    ```sql
+    -- Count unique Client IDs observed on a given day
+    SELECT
+      count(distinct client_info.client_id)
+    FROM
+      org_mozilla_fenix.baseline
+    WHERE
+      date(submission_timestamp) = '2019-11-11'
+    ```
+
+* _(Work in progress)_ Use events and [Amplitude](https://sso.mozilla.com/amplitude) for product analytics.
+* [Use Databricks](https://sso.mozilla.com/databricks) for deep-dive analysis.
+* [Use the Glean debug ping viewer](debug_ping_view.md) for QA & development.
+* For experimentation, you will be able to use [Android experiments library](https://github.com/mozilla-mobile/android-components/blob/master/components/service/experiments/README.md), which integrates with Glean.
 
 # Contact
 


### PR DESCRIPTION
Current rendering:

![Screenshot_2019-12-16 Glean overview - Firefox Data Documentation](https://user-images.githubusercontent.com/2129/70927032-86c71580-202e-11ea-9125-83f7bb728128.png)

New rendering:

<img width="1114" alt="ac605626f9" src="https://user-images.githubusercontent.com/2129/70927052-8fb7e700-202e-11ea-95ff-99277702ce8e.png">


---

Yes, a bit more whitespace, but at least the code is nicely rendered!

