### PR TITLE
Add "open on GitHub" link to pages

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -151,6 +151,7 @@ MacOS
 McCrosky
 mdbook
 mdbook-toc
+mdbook-open-on-gh
 Melancon
 metadata
 metastore

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
         - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git rust-lang/mdBook
         - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-toc
         - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-mermaid
+        - curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-open-on-gh
         - mdbook --version
         - mdbook-toc --version
         - mdbook-mermaid --version

--- a/book.toml
+++ b/book.toml
@@ -15,3 +15,6 @@ command = "mdbook-toc"
 additional-css = ["dtmo.css", "mermaid.css"]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
 git-repository-url = "https://github.com/mozilla/firefox-data-docs"
+
+[preprocessor.open-on-gh]
+command = "mdbook-open-on-gh"

--- a/book.toml
+++ b/book.toml
@@ -14,3 +14,4 @@ command = "mdbook-toc"
 [output.html]
 additional-css = ["dtmo.css", "mermaid.css"]
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
+git-repository-url = "https://github.com/mozilla/firefox-data-docs"

--- a/dtmo.css
+++ b/dtmo.css
@@ -4,3 +4,10 @@
 .content code mark {
     display: inline-block;
 }
+
+footer#open-on-gh {
+  font-size: 0.8em;
+  text-align: center;
+  border-top: 1px solid black;
+  padding: 5px 0;
+}

--- a/src/meta/contributing.md
+++ b/src/meta/contributing.md
@@ -26,6 +26,7 @@ To build the documentation locally, you'll need additional preprocessors:
 
 * [mdbook-toc](https://github.com/badboy/mdbook-toc/releases)
 * [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid/releases)
+* [mdbook-open-on-gh](https://github.com/badboy/mdbook-open-on-gh/releases)
 
 Download releases for your system, unpack it and place the binary in a directory of your `$PATH`.
 
@@ -34,6 +35,7 @@ If you have [rustc](https://www.rust-lang.org/) already installed, you can insta
 ```bash
 curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-toc
 curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-mermaid
+curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git badboy/mdbook-open-on-gh
 ```
 
 This will place `mdbook-toc` and `mdbook-mermaid` into `~/.cargo/bin`.
@@ -44,6 +46,7 @@ You can also build and install the preprocessors:
 ```bash
 cargo install mdbook-toc
 cargo install mdbook-mermaid
+cargo install mdbook-open-on-gh
 ```
 
 You can then serve the documentation locally with:


### PR DESCRIPTION
This adds a new "open this file on GitHub" link on the bottom of each page, making it easier to jump in and fix the documentation.
See screenshot.

![](https://tmp.fnordig.de/scr/a22c20745c.png)