### PR TITLE
Fix broken links to dev branch of mozilla-pipeline-schemas

### DIFF
--- a/src/concepts/pipeline/data_pipeline_detail.md
+++ b/src/concepts/pipeline/data_pipeline_detail.md
@@ -396,7 +396,7 @@ graph LR
 [cep]: BROKEN:http://pipeline-cep.prod.mozaws.net/
 [Mission Control]: https://data-missioncontrol.dev.mozaws.net
 [Metrics Graphics]: http://metricsgraphicsjs.org/
-[parquet]: http://parquet.apache.org/
+[parquet]: https://parquet.apache.org/
 [Hive]: https://cwiki.apache.org/confluence/display/Hive/Home
 [Presto]: http://prestosql.io/
 [Telemetry Aggregates]: https://github.com/mozilla/python_mozaggregator/#api

--- a/src/concepts/pipeline/event_pipeline.md
+++ b/src/concepts/pipeline/event_pipeline.md
@@ -110,7 +110,7 @@ can follow the event data format and potentially connect to the existing tooling
 
 ## Mobile event collection
 
-Mobile events data primarily flows through the mobile events ping ([ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/dev/schemas/telemetry/mobile-event)), from e.g. [Firefox iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Event-Tracking-with-Mozilla's-Telemetry-Service#event-ping), Firefox for Fire TV and Rocket.
+Mobile events data primarily flows through the mobile events ping ([ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/master/schemas/telemetry/mobile-event)), from e.g. [Firefox iOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Event-Tracking-with-Mozilla's-Telemetry-Service#event-ping), Firefox for Fire TV and Rocket.
 
 Currently we also collect event data from Firefox Focus through the [`focus-events` ping](https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service#event-ping),
 using the [`telemetry-ios`](https://github.com/mozilla-mobile/telemetry-ios) and

--- a/src/datasets/other/hgpush/reference.md
+++ b/src/datasets/other/hgpush/reference.md
@@ -12,11 +12,11 @@ Use the `eng_workflow_hgpush_parquet_v1` table with the `Athena` data source.
 
 ## Field Types and Descriptions
 
-See the [`hgpush` ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/dev/schemas/eng-workflow/hgpush/hgpush.1.schema.json)
+See the [`hgpush` ping schema](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/eng-workflow/hgpush/hgpush.1.schema.json)
 for a description of available fields.
 
 Be careful to:
- * Use the latest schema version.  e.g. `v1`.  Browse the [`hgpush` schema directory](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/dev/schemas/eng-workflow/hgpush) in the GitHub repo to be sure.
+ * Use the latest schema version.  e.g. `v1`.  Browse the [`hgpush` schema directory](https://github.com/mozilla-services/mozilla-pipeline-schemas/tree/master/schemas/eng-workflow/hgpush) in the GitHub repo to be sure.
  * Change dataset field names from `camelCaseNames` to `under_score_names` in STMO. e.g. `reviewSystemUsed` in the ping schema becomes `review_system_used` in STMO.
 
 ## Example Queries


### PR DESCRIPTION
The dev branch is no more. The source of truth is `master`.