### PR TITLE
Allow link-check to fail again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
       script:
         - npm install markdown-link-check -g
         - bash scripts/link_check.sh
-jobs:
   allow_failures:
   - name: link-check
 deploy:


### PR DESCRIPTION
A configuration change in travis made it so that we had to place this directive
inside the matrix itself.