### PR TITLE
Improvements to "getting in touch"

### DIFF
--- a/src/concepts/analysis_intro.md
+++ b/src/concepts/analysis_intro.md
@@ -90,7 +90,7 @@ that probe (Metric Count).
   [And yes, that does happen.][problem_client]
 * Sometimes it looks like no data is there, but you think there should be.
   Check under advanced settings and check "Don't Sanitize" and "Don't Trim Buckets".
-  If it's still not there, let us know in IRC on #telemetry.
+  If it's still not there, see [getting help](getting_help.md).
 * TMO Measurement Dashboards do not currently show release-channel data.
   Release-channel data [ceased being aggregated][prefs] as of Firefox 58.
   We're looking into ways of doing this correctly in the near future.

--- a/src/concepts/getting_help.md
+++ b/src/concepts/getting_help.md
@@ -4,23 +4,22 @@
 
 Telemetry-related announcements including new datasets, outages, feature
 releases, etc are sent to [`fx-data-dev@mozilla.org`][fx-data-dev], a public
-mailing list.
-Please subscribe to the [mailing list here][subscribe].
+mailing list (follow the link for archives and information on how to subscribe).
 
 There's also an internal mailing list,
 [`fx-data-platform@mozilla.com`][fx-data-platform],
 meant for internal data platform team communications.
 Please speak to your manager if you believe you should be on the list.
 
-### IRC
+### Matrix
 
-The data platform team is available in `#telemetry` on `irc.mozilla.org`.
-For pipeline-specific issues, you can also find us in `#datapipeline`.
+You can find us in the [#telemetry:mozilla.org] channel on [Mozilla's instance of matrix].
 
 ### Slack
 
 The Mozilla data org is reachable at `#fx-metrics` in the internal Mozilla Slack.
 
-[fx-data-dev]: mailto:fx-data-dev@mozilla.org
-[subscribe]: https://mail.mozilla.org/listinfo/fx-data-dev
+[fx-data-dev]: https://mail.mozilla.org/listinfo/fx-data-dev
 [fx-data-platform]: mailto:fx-data-platform@mozilla.com
+[#telemetry:mozilla.org]: https://chat.mozilla.org/#/room/#telemetry:mozilla.org
+[Mozilla's instance of matrix]: https://wiki.mozilla.org/Matrix

--- a/src/concepts/glean/glean.md
+++ b/src/concepts/glean/glean.md
@@ -71,7 +71,7 @@ To make it easier to understand the general semantics of our data, the Glean SDK
 # Contact
 
 *   `#glean` & `#fx-metrics` on slack
-*   `#glean:mozilla.org` on matrix
+*   [#glean:mozilla.org](https://chat.mozilla.org/#/room/#glean:mozilla.org) on matrix
 *   [`glean-team@mozilla.com`](mailto:glean-team@mozilla.com) to reach out
 *   [`fx-data-dev@mozilla.com`](mailto:fx-data-dev@mozilla.com) for announcements etc.
 

--- a/src/concepts/reporting_a_problem.md
+++ b/src/concepts/reporting_a_problem.md
@@ -12,8 +12,7 @@ in the [General component](https://bugzilla.mozilla.org/enter_bug.cgi?product=Da
 Components are triaged at least weekly by the component owner(s). For issues needing
 urgent attention, it is recommended that you use the `needinfo` flag to attract attention
 from a specific person. If an issue doesn't receive the appropriate attention within a
-week, you can send email to the `fx-data-dev` mailing list, reach out on IRC
-in `#datapipeline`, or on Slack in `#fx-metrics`.
+week (or it's urgent), you can find out how to reach us in the [getting help](getting_help.md) section.
 
 When a bug is triaged, it will be assigned a **priority** and **points**. **Priorities** have the
 following meanings:

--- a/src/cookbooks/bigquery.md
+++ b/src/cookbooks/bigquery.md
@@ -176,7 +176,7 @@ but it has changed from `YYYYMMDD` string form to a proper `DATE` type that acce
 - Unqualified queries can become very costly very easily. We've placed restrictions on large tables from accidentally querying "all data for all time",
 namely that you must make use of the date partition fields for large tables (like `main_summary` or `clients_daily`).
 - Please read [_Query Optimizations_](bigquery.md#query-optimizations) section that contains advice on how to reduce cost and improve query performance.
-- re:dash BigQuery data sources will have a 10 TB data scanned limit per query. Please let us know in `#fx-metrics` on Slack if you run into issues!
+- re:dash BigQuery data sources will have a 10 TB data scanned limit per query. Please [let us know](../concepts/getting_help.md) if this becomes an issue.
 - There is no native map support in BigQuery. Instead, we are using structs with fields [key, value]. We have provided convenience functions to access these like key-value maps (described [below](bigquery.md#accessing-map-like-fields).)
 
 ### Projects with BigQuery datasets

--- a/src/tools/alerts.md
+++ b/src/tools/alerts.md
@@ -143,7 +143,7 @@ clicking on the plot's title. Open another tab to the Evolution View.
 
 5\. If you _still_ don't know what's going on
 
--   find a domain expert on IRC and bother them to help you out. Domain
+-   find a domain expert and bother them to help you out (see [getting help](../concepts/getting_help.md)). Domain
     knowledge is awesome.
 
 From pursuing these steps or sub-steps you should now have two things: a

--- a/src/tools/alerts.md
+++ b/src/tools/alerts.md
@@ -143,7 +143,7 @@ clicking on the plot's title. Open another tab to the Evolution View.
 
 5\. If you _still_ don't know what's going on
 
--   find a domain expert and bother them to help you out (see [getting help](../concepts/getting_help.md)). Domain
+-   find a domain expert and ask them to help you out (see [getting help](../concepts/getting_help.md)). Domain
     knowledge is awesome.
 
 From pursuing these steps or sub-steps you should now have two things: a

--- a/src/tools/interfaces.md
+++ b/src/tools/interfaces.md
@@ -19,8 +19,7 @@ reported in our [issue tracker](https://github.com/mozilla/redash/issues).
 
 Offers notebook interface with shared, always-on, autoscaling cluster
 (attaching your notebooks to `shared_serverless_python3` is the best way to start).
-Convenient for quick data investigations. Users can get help on `#databricks`
-channel on IRC and are advised to join the
+Convenient for quick data investigations. Users are advised to join the
 [`databricks-discuss@mozilla.com`](https://groups.google.com/a/mozilla.com/forum/#!forum/databricks-discuss) group.
 
 #### [`telemetry.mozilla.org`](../concepts/analysis_intro.md) (TMO)

--- a/src/tools/stmo.md
+++ b/src/tools/stmo.md
@@ -71,8 +71,7 @@ own Re:dash database. You can learn more about the available data sets and how
 to find the one that's right for you on the [Choosing a
 dataset](../concepts/choosing_a_dataset.md) page. If you have data set
 questions, or would like to know if specific data is or can be made available
-in STMO, please inquire in the `#datapipeline` or `#datatools` channels on
-`irc.mozilla.org`; or in `#fx-metrics` on Slack.
+in STMO, please see the [getting help](../concepts/getting_help.md) section for information on how to get in touch.
 
 Creating an Example Dashboard
 -----------------------------
@@ -108,8 +107,7 @@ which is generated from Firefox telemetry pings.
 
   Again, there are many different data sources connected to STMO, so if the
   one you want is not in the Telemetry source, we should check other sources.
-  If you're having trouble finding the data you need, feel free to ask in
-  `#fx-metrics` on Slack
+  If you're having trouble finding the data you need, see the [getting help](../concepts/getting_help.md) section.
 
 * Introspect the available columns
 


### PR DESCRIPTION
* Reference Matrix, not IRC
* Change a bunch of adhoc recommendations to "ask in #fx-metrics"
  or "ask in #telemetry" to redirect to the getting help section
* Various other minor tweaks