### PR TITLE
Sync schema with ETL query

### DIFF
--- a/src/datasets/search/search_clients_daily/reference.md
+++ b/src/datasets/search/search_clients_daily/reference.md
@@ -60,8 +60,8 @@ root
  |-- tab_open_event_count_sum: long (nullable = true)
  |-- active_hours_sum: double (nullable = true)
  |-- total_uri_count: long (nullable = true)
- |-- tagged-sap: long (nullable = true)
- |-- tagged-follow-on: long (nullable = true)
+ |-- tagged_sap: long (nullable = true)
+ |-- tagged_follow_on: long (nullable = true)
  |-- sap: long (nullable = true)
  |-- tagged_sap: long (nullable = true)
  |-- tagged_follow_on: long (nullable = true)
@@ -69,6 +69,12 @@ root
  |-- search_with_ads: long (nullable = true)
  |-- ad_click: long (nullable = true)
  |-- unknown: long (nullable = true)
+ |-- normalized_engine: string (nullable = true)
+ |-- user_pref_browser_search_region: string (nullable = true)
+ |-- is_default_browser: boolean (nullable = true)
+ |-- experiments: map (nullable = true)
+ |    |-- key: string
+ |    |-- value: string
 ```
 
 # Code Reference


### PR DESCRIPTION
Update the ``search_clients_daily`` schema to match the [ETL query](https://github.com/mozilla/bigquery-etl/blob/3f1cb398fa3eb162c232480d8cfa97b8952ee658/sql/search_derived/search_clients_daily_v8/query.sql):

* ``submission_date_s3`` - Not in ETL query, but does appear to be available in recent queries
* ``tagged-sap`` - ``tagged_sap`` (underscore) in ETL query
* ``tagged-follow-on`` - ``tagged_follow_on`` (underscores) in ETL query
* ``normalized_engine`` - In ETL query, not in schema
* ``user_pref_browser_search_region`` - In ETL query, not in schema
* ``is_default_browser`` - In ETL query, not in schema
* ``experiments`` -  In ETL query, not in schema

The schema appears to be a generated section, but these changes are hand-edited.  The types are my best guess from looking at the code.