### PR TITLE
Skip link check for monitor.firefox.com

### DIFF
--- a/.linkcheck.json
+++ b/.linkcheck.json
@@ -11,5 +11,6 @@
         { "pattern": "^https://github.com/mozilla/stmo_core_product_metrics" },
         { "pattern": "^https://github.com/mozilla-services/cloudops-infra" },
         { "pattern": "^https://docs.google.com" }
+        { "pattern": "^https://monitor.firefox.com$" }
     ]
 }

--- a/src/datasets/fxa.md
+++ b/src/datasets/fxa.md
@@ -21,7 +21,7 @@ This article provides an overview of Firefox Accounts metrics: what is measured 
     * For developer accounts; not required by end-users to use or download addons.
 * [Pocket](https://getpocket.com/login/?ep=1)
     * FxA is an optional authentication method among others.
-* [Monitor](http://monitor.firefox.com/)
+* [Monitor](https://monitor.firefox.com)
     * Required to receive email alerts. Not required for email scans.
 * [Mozilla IAM](https://wiki.mozilla.org/IAM/Frequently_asked_questions)
     * Optional authentication method among others.

--- a/src/datasets/fxa_metrics/attribution.md
+++ b/src/datasets/fxa_metrics/attribution.md
@@ -18,7 +18,7 @@ There is a variable called `service` that we use to (1) attribute users to the r
 |`lockbox`|`e7ce535d93522896`|Lockwise App for Android|
 |`lockbox`|`98adfa37698f255b`|Lockwise App for iOS|
 |`fenix`|`a2270f727f45f648`|Sync implementation for Fenix|
-|`fx-monitor`|`802d56ef2a9af9fa`|Firefox Monitor ([website](https://monitor.firefox.com/))|
+|`fx-monitor`|`802d56ef2a9af9fa`|Firefox Monitor ([website](https://monitor.firefox.com))|
 |`send`|`1f30e32975ae5112`|Firefox Send ([website](https://send.firefox.com/))|
 |`send`|`20f7931c9054d833`|Firefox Send (android app)|
 |`pocket-mobile`|`7377719276ad44ee`|Pocket Mobile App|


### PR DESCRIPTION
The link checker failed regularly with this error:

[✖] https://monitor.firefox.com/ → Status: 0 Error: ESOCKETTIMEDOUT

Add this site to the ignore list as a workaround.