### PR TITLE
Document dynamic telemetry

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -86,6 +86,7 @@ DevTools
 discoverability
 Django's
 DLLs
+DNS
 Dockerfile
 DWL
 DXR

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -68,6 +68,7 @@
   * [Experimental Datasets](tools/experiments.md)
     * [Accessing Heartbeat data](datasets/heartbeat.md)
     * [Accessing Shield Study data](datasets/shield.md)
+    * [Dynamic telemetry](datasets/dynamic_telemetry.md)
   * [Search Datasets](datasets/search.md)
     * [Search Aggregates](datasets/search/search_aggregates/reference.md)
     * [Search Clients Daily](datasets/search/search_clients_daily/reference.md)

--- a/src/datasets/dynamic_telemetry.md
+++ b/src/datasets/dynamic_telemetry.md
@@ -1,0 +1,23 @@
+# Dynamic telemetry
+
+Add-on studies may choose to implement new
+[scalar] or [event] telemetry probes.
+These probes are not described in
+the probe metadata files in the Firefox source tree
+and are not described in the [probe dictionary].
+Often, they are documented in the repositories
+associated with the add-on studies instead.
+
+There is no complete central reference for these.
+This page is intended as a partial historical reference
+for these probes.
+
+| Start date | Study  | Probe type | Probe names | Documentation |
+| ---------- | ------ | ---------- | ----------- | ------------- |
+| 2020-04 | [HTTP Upgrade](https://bugzilla.mozilla.org/show_bug.cgi?id=1623996) | scalar | `httpsUpgradeStudy.https`, `httpsUpgradeStudy.nonupgradable`, `httpsUpgradeStudy.upgradable` | https://bugzilla.mozilla.org/show_bug.cgi?id=1629585 |
+| 2020-02 | [Search interventions](https://bugzilla.mozilla.org/show_bug.cgi?id=1564506) | scalar | `urlbarInterventionsExperiment.tipShownCount`, `.tipPickedCount` | missing |
+| 2019-10 | [DNS over HTTPS heuristics](https://bugzilla.mozilla.org/show_bug.cgi?id=1573840) | event | `doh#evaluate.heuristics`, `doh#state` | https://github.com/mozilla/doh-rollout/blob/6787458a6901ef3b2a8fef86a179899213809534/docs/telemetry.md |
+
+[scalar]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/collection/scalars.html
+[event]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/collection/events.html
+[probe dictionary]: https://probes.telemetry.mozilla.org/

--- a/src/datasets/dynamic_telemetry.md
+++ b/src/datasets/dynamic_telemetry.md
@@ -16,6 +16,7 @@ for these probes.
 | ---------- | ------ | ---------- | ----------- | ------------- |
 | 2020-04 | [HTTP Upgrade](https://bugzilla.mozilla.org/show_bug.cgi?id=1623996) | scalar | `httpsUpgradeStudy.https`, `httpsUpgradeStudy.nonupgradable`, `httpsUpgradeStudy.upgradable` | https://bugzilla.mozilla.org/show_bug.cgi?id=1629585 |
 | 2020-02 | [Search interventions](https://bugzilla.mozilla.org/show_bug.cgi?id=1564506) | scalar | `urlbarInterventionsExperiment.tipShownCount`, `.tipPickedCount` | missing |
+| 2019-10 | [Delegated credentials](https://bugzilla.mozilla.org/show_bug.cgi?id=1594926) | event | `delegatedcredentials#connectDC`, `#connectNoDC` | https://github.com/kjacobs-moz/dc-experiment-addon |
 | 2019-10 | [DNS over HTTPS heuristics](https://bugzilla.mozilla.org/show_bug.cgi?id=1573840) | event | `doh#evaluate.heuristics`, `doh#state` | https://github.com/mozilla/doh-rollout/blob/6787458a6901ef3b2a8fef86a179899213809534/docs/telemetry.md |
 
 [scalar]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/collection/scalars.html


### PR DESCRIPTION
Begin a reference for scalars and events that are added by addons, and are missing from the in-tree Scalars.yaml and Events.yaml, and therefore aren't described by the probe dictionary.

The goal is to improve the visibility of the documentation that data collection review requires for these probes, since otherwise they're just kind of scattered through a bunch of random add-on repositories.