### PR TITLE
Install parallel into CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  apt:
+    - parallel
 matrix:
   include:
     - name: build


### PR DESCRIPTION
This gives nicer output for the parallel link check. This went missing in #365 and I'm not sure if it was intentional.