### PR TITLE
Segments v3

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -307,6 +307,7 @@ utm
 UUID
 v1
 v2
+v3
 v4
 versioned
 versioning

--- a/src/concepts/segments.md
+++ b/src/concepts/segments.md
@@ -31,34 +31,6 @@ This segment contains clients who sent pings on _at least 14_ of the previous 27
 
 This segment contains clients who sent pings on _none_ of the previous 27 days. As of February 2020 this segment contained approximately 4% of DAU and its users had a 1-week retention of approximately 30%.
 
-## Obsolete segments
-
-### Usage regularity v2
-
-This is a set of three segments. 
-On a given day, every client falls into exactly one of these segments.
-Each client's segment can be computed from `telemetry.clients_last_seen.days_visited_5_uri_bits`.
-
-
-*Regular users v2* is defined as 
-clients who browsed >=5 URIs on _at least eight_ of the previous 27 days.
-As of February 2020 this segment contained approximately 2/3 of DAU
-and its users had a 1-week retention for a 5 URI day usage criterion of approximately 95%.
-
-*New/irregular users v2* is defined as 
-clients who browsed >=5 URIs on _none_ of the previous 27 days.
-As of February 2020 this segment contained approximately 15% of DAU,
-and had a retention for a 5 URI day usage criterion of about 10%
-(though "activation" is likely a more relevant word than "retention" for many of these clients).
-
-*Semi-regular users v2* is defined as
-clients who browsed >=5 URIs on _between one and seven_ of the previous 27 days,
-i.e. it contains users who do not fit the other two segments at this time.
-As of February 2020 this segment contained approximately 20% of DAU,
-and had a retention for a 5 URI day usage criterion of about 60%.
-We do not yet know what proportion of users in this segment stay in this segment for an extended period, and what proportion are in transition between other segments.
-
-
 ## Writing queries with segments
 
 When a segment is defined with respect to a user's _behavior_ (e.g. usage levels) 
@@ -111,3 +83,31 @@ INNER JOIN clients_last_seen cls
 WHERE
     cd.submission_date BETWEEN '2020-01-01' AND '2020-03-01'
 ```
+
+
+## Obsolete segments
+
+### Usage regularity v2
+
+This is a set of three segments. 
+On a given day, every client falls into exactly one of these segments.
+Each client's segment can be computed from `telemetry.clients_last_seen.days_visited_5_uri_bits`.
+
+
+*Regular users v2* is defined as 
+clients who browsed >=5 URIs on _at least eight_ of the previous 27 days.
+As of February 2020 this segment contained approximately 2/3 of DAU
+and its users had a 1-week retention for a 5 URI day usage criterion of approximately 95%.
+
+*New/irregular users v2* is defined as 
+clients who browsed >=5 URIs on _none_ of the previous 27 days.
+As of February 2020 this segment contained approximately 15% of DAU,
+and had a retention for a 5 URI day usage criterion of about 10%
+(though "activation" is likely a more relevant word than "retention" for many of these clients).
+
+*Semi-regular users v2* is defined as
+clients who browsed >=5 URIs on _between one and seven_ of the previous 27 days,
+i.e. it contains users who do not fit the other two segments at this time.
+As of February 2020 this segment contained approximately 20% of DAU,
+and had a retention for a 5 URI day usage criterion of about 60%.
+We do not yet know what proportion of users in this segment stay in this segment for an extended period, and what proportion are in transition between other segments.

--- a/src/concepts/segments.md
+++ b/src/concepts/segments.md
@@ -23,34 +23,39 @@ so that your communication is forwards compatible.
 
 ## Current segments
 
+### Regular users v3
+
+### New & Resurrected users v3
+
+
+
+## Obsolete segments
+
 ### Usage regularity v2
 
 This is a set of three segments. 
 On a given day, every client falls into exactly one of these segments.
-Each client's segment is stored in `telemetry.clients_last_seen.segment_usage_regularity_v2`.
+Each client's segment can be computed from `telemetry.clients_last_seen.days_visited_5_uri_bits`.
 
 
 *Regular users v2* is defined as 
 clients who browsed >=5 URIs on _at least eight_ of the previous 27 days.
 As of February 2020 this segment contained approximately 2/3 of DAU
-and its users had a 1-week retention of approximately 95%.
+and its users had a 1-week retention for a 5 URI day usage criterion of approximately 95%.
 
 *New/irregular users v2* is defined as 
 clients who browsed >=5 URIs on _none_ of the previous 27 days.
 As of February 2020 this segment contained approximately 15% of DAU,
-and had a retention of about 10%
+and had a retention for a 5 URI day usage criterion of about 10%
 (though "activation" is likely a more relevant word than "retention" for many of these clients).
 
 *Semi-regular users v2* is defined as
 clients who browsed >=5 URIs on _between one and seven_ of the previous 27 days,
 i.e. it contains users who do not fit the other two segments at this time.
 As of February 2020 this segment contained approximately 20% of DAU,
-and had a retention of about 60%.
+and had a retention for a 5 URI day usage criterion of about 60%.
 We do not yet know what proportion of users in this segment stay in this segment for an extended period, and what proportion are in transition between other segments.
 
-## Obsolete segments
-
-None yet.
 
 ## Writing queries with segments
 

--- a/src/concepts/segments.md
+++ b/src/concepts/segments.md
@@ -27,7 +27,7 @@ so that your communication is forwards compatible.
 
 This segment contains clients who sent pings on _at least 14_ of the previous 27 days. As of February 2020 this segment contained approximately 2/3 of DAU and its users had a 1-week retention of around 95%.
 
-### New or Revived v3
+### New or Resurrected v3
 
 This segment contains clients who sent pings on _none_ of the previous 27 days. As of February 2020 this segment contained approximately 4% of DAU and its users had a 1-week retention of approximately 30%.
 

--- a/src/concepts/segments.md
+++ b/src/concepts/segments.md
@@ -18,16 +18,18 @@ or is it global and therefore not solely due to that event?"
 
 We are building out our library of segments, 
 and we want room to iterate to improve them in the future. 
-So please quote segments' versions with their names, e.g. "regular users v2"
+So please quote segments' versions with their names, e.g. "regular users v3"
 so that your communication is forwards compatible.
 
 ## Current segments
 
 ### Regular users v3
 
-### New & Resurrected users v3
+This segment contains clients who sent pings on _at least 14_ of the previous 27 days. As of February 2020 this segment contained approximately 2/3 of DAU and its users had a 1-week retention of around 95%.
 
+### New or Revived v3
 
+This segment contains clients who sent pings on _none_ of the previous 27 days. As of February 2020 this segment contained approximately 4% of DAU and its users had a 1-week retention of approximately 30%.
 
 ## Obsolete segments
 
@@ -84,24 +86,23 @@ So stick to DAU for now.
 
 ### Example queries
 
-DAU for _regular users v2_:
+DAU for _regular users v3_:
 ```lang=sql
 SELECT
     submission_date,
-    COUNT(*) AS dau_regular_users_v2
+    COUNTIF(BIT_COUNT(days_seen_bits & 0x0FFFFFFE) >= 14) AS dau_regular_users_v3
 FROM moz-fx-data-shared-prod.telemetry.clients_last_seen
 WHERE
     submission_date BETWEEN '2020-01-01' AND '2020-03-01'
-    AND segment_usage_regularity_v2 = 'regular_users_v2'
     AND days_since_seen = 0  -- Get DAU from clients_last_seen
 GROUP BY submission_date
 ```
 
-DAU for _regular users v2_, but joining from a different table:
+DAU for _regular users v3_, but joining from a different table:
 ```lang=sql
 SELECT
     cd.submission_date,
-    COUNT(*) AS dau_regular_users_v2
+    COUNTIF(BIT_COUNT(cls.days_seen_bits & 0x0FFFFFFE) >= 14) AS dau_regular_users_v3
 FROM clients_daily cd
 INNER JOIN clients_last_seen cls
     ON cls.client_id = cd.client_id
@@ -109,5 +110,4 @@ INNER JOIN clients_last_seen cls
     AND cls.submission_date BETWEEN '2020-01-01' AND '2020-03-01'
 WHERE
     cd.submission_date BETWEEN '2020-01-01' AND '2020-03-01'
-    AND cls.segment_usage_regularity_v2 = 'regular_users_v2'
 ```


### PR DESCRIPTION
We're switching from using `days_visited_5_uri_bits` to `days_seen_bits`. After "usage regularity v2", we discovered that there's a relatively large contingent of users who are seen (i.e. send a ping) regularly but very rarely visit 5 URIs. Many/most of them seem to be actively using the browser (active hours > 0), probably in private browsing mode (or there are telemetry bugs meaning their URIs aren't getting recorded?). This accounted for most of the DAU in `new_irregular_users_v2`(!)

So predicting 1-week retention with a usage criterion of "had a 5 uri day" is a sub-optimal goal for our segment definitions. I first tried switching this goal to "predicting 1-week retention with a usage criterion of 'sent a ping'", but this seemed too easy: retention (for one day of users) is high enough (or: the target classes were imbalanced enough) that I wasn't confident that we'd learn what we needed to learn. I set the harder task of "predict whether the user will send a ping in 0, 1, 2, or all 3 of the following three weeks".

Having set this as the goal, `days_seen_bits`-derived features started outperforming `days_visited_5_uri_bits` features.

But the "divide users into three segments to maximise MI" approach started to become less useful: the optimal definitions were [0, 4], (4, 11], (11, 27] days seen in the past 27.

The "[0, 4]" segment is not so useful in an experiment context, where we want to learn the effect of a feature on new (and resurrected) users, but we don't want this polluted by the effect of the feature on users who experienced the old version for their first 1-4 days and then the new feature - because this is a niche short-term effect that shouldn't play a role in our decision making. So we do really want - at least for some usecases - a segment of brand new/newly resurrected users.

MI with three segments wasn't giving us this segment, because it's a tiny fraction of DAU (~4%) and thus doesn't provide as much information as a segment closer to the optimal 1/3 of users. So I took the _class_ of feature ("x days out of the past 27") from the MI approach, and manually set a threshold that's suboptimal for MI but should be most useful for product reasons. In the future, we may well want to add a segment akin to the "[0, 4] days in the past 27" - in addition to this one, not instead of it. That new segment would probably seek to contain new users that are yet to activate.

Then the question was how to get a "regular users" segment - ideally one where the week 1 retention for a cohort was similar to the week n to n+1 retention drop (i.e. where the curve for the segment in [this graph](https://sql.telemetry.mozilla.org/queries/70030/source#176415) is as smooth as possible at week 1). Amongst other quantities, I plotted a receiver operating characteristic (ROC) curve for ">=n days seen in the past 27" at predicting whether a user would retain for all three of the following weeks. I also plotted the precision-recall curve.

Any threshold between 12-18 seemed to be a sensible threshold for days_seen - balancing the size of the segment and the fraction of users who go on to browse in all three future weeks. In the interest of applying these quickly, I picked 14. This means that the segment contains about 61% of DAU, and the marginal users (i.e. just inside the threshold) had an 85% probability of continuing to use the browser for all three subsequent weeks.

[Jupyter notebook here](https://metrics.mozilla.com/protected/flawrence/segments/clients_last_seen_MI_v6.html)