### PR TITLE
Remove links to the Fx-Data-Planning repo.

### DIFF
--- a/.linkcheck.json
+++ b/.linkcheck.json
@@ -6,7 +6,6 @@
         { "pattern": "^https://circleci.com/gh/mozilla/pensieve/edit" },
         { "pattern": "^https://github.com/mozilla-services/puppet-config" },
         { "pattern": "^https://github.com/mozilla-services/spark-parquet-to-bigquery" },
-        { "pattern": "^https://github.com/mozilla/Fx-Data-Planning" },
         { "pattern": "^https://sql.telemetry.mozilla.org" },
         { "pattern": "^https://github.com/mozilla/stmo_core_product_metrics" },
         { "pattern": "^https://github.com/mozilla-services/cloudops-infra" },

--- a/src/tools/projects.md
+++ b/src/tools/projects.md
@@ -154,6 +154,3 @@ starting a new project using anything in this section.
 
 | Name and repo                  | Description                             |
 |--------------------------------|-----------------------------------------|
-| [`Fx-Data-Planning`][planning] | Quarterly goals and internal documentation
-
-[planning]: https://github.com/mozilla/Fx-Data-Planning


### PR DESCRIPTION
The content from that repository has been migrated to Mana at
https://mana.mozilla.org/wiki/display/DENG

and may soon move to be linked from:
https://mana.mozilla.org/wiki/display/DATA

There is a corresponding issue at https://github.com/mozilla/Fx-Data-Planning/issues/56