### PR TITLE
Replace links to dxr with searchfox.

### DIFF
--- a/src/concepts/analysis_intro.md
+++ b/src/concepts/analysis_intro.md
@@ -107,7 +107,7 @@ Where to go next
 [probe_dict]: https://probes.telemetry.mozilla.org/
 [events]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html
 [histograms]: https://github.com/mozilla/gecko-dev/blob/master/toolkit/components/telemetry/Histograms.json
-[scalars]: https://dxr.mozilla.org/mozilla-central/rev/tip/toolkit/components/telemetry/Scalars.yaml
+[scalars]: https://searchfox.org/mozilla-central/source/toolkit/components/telemetry/Scalars.yaml
 [tmo]: https://telemetry.mozilla.org/
 [measurement_dash]: https://telemetry.mozilla.org/new-pipeline/dist.html
 [evo_dash]: https://telemetry.mozilla.org/new-pipeline/evo.html

--- a/src/concepts/pipeline/data_pipeline.md
+++ b/src/concepts/pipeline/data_pipeline.md
@@ -179,7 +179,7 @@ There is a vast ecosystem of tools for processing data at scale, each with their
 [main ping]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html
 [ping types]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/concepts/pings.html#ping-types
 [create their own ping types]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/custom-pings.html
-[API]: https://dxr.mozilla.org/mozilla-central/rev/6a23526fe5168087d7e4132c0705aefcaed5f571/toolkit/components/telemetry/TelemetryController.jsm#202
+[API]: https://searchfox.org/mozilla-central/rev/501eb4718d73870892d28f31a99b46f4783efaa0/toolkit/components/telemetry/app/TelemetryController.jsm#231
 [submit]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/concepts/submission.html#submission
 [load balancer]: https://aws.amazon.com/elasticloadbalancing/
 [module]: https://github.com/mozilla-services/nginx_moz_ingest

--- a/src/concepts/pipeline/gcp_data_pipeline.md
+++ b/src/concepts/pipeline/gcp_data_pipeline.md
@@ -183,7 +183,7 @@ Data analysis is most commonly done using [SQL queries][stmo] or using [Spark].
 [main ping]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/main-ping.html
 [ping types]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/concepts/pings.html#ping-types
 [create their own ping types]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/custom-pings.html
-[API]: https://dxr.mozilla.org/mozilla-central/rev/6a23526fe5168087d7e4132c0705aefcaed5f571/toolkit/components/telemetry/TelemetryController.jsm#202
+[API]: https://searchfox.org/mozilla-central/rev/501eb4718d73870892d28f31a99b46f4783efaa0/toolkit/components/telemetry/app/TelemetryController.jsm#231
 [submit]: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/concepts/submission.html#submission
 [Airflow]: https://github.com/mozilla/telemetry-airflow/
 [TMO]: https://telemetry.mozilla.org/

--- a/src/cookbooks/events_best_practices.md
+++ b/src/cookbooks/events_best_practices.md
@@ -21,9 +21,10 @@ These records are then stored in [event pings](https://firefox-source-docs.mozil
 
 ## Identifying Events
 
-One challenge with this data is it can be difficult to identify all the records from a particular event. Unlike Scalars and Histograms, which keep data in individual locations (like `scalar_parent_browser_engagement_total_uri_count` for [`total_uri_count`](https://dxr.mozilla.org/mozilla-central/source/toolkit/components/telemetry/Scalars.yaml#99)), all event records are stored together, regardless of which event generated them. The records themselves don't have a field identifying which event produced it[1].
+One challenge with this data is it can be difficult to identify all the records from a particular event.
+Unlike Scalars and Histograms, which keep data in individual locations (like `scalar_parent_browser_engagement_total_uri_count` for [`total_uri_count`](https://searchfox.org/mozilla-central/rev/501eb4718d73870892d28f31a99b46f4783efaa0/toolkit/components/telemetry/Scalars.yaml#204)), all event records are stored together, regardless of which event generated them. The records themselves don't have a field identifying which event produced it[1].
 
-Take, for example, the [`manage`](https://dxr.mozilla.org/mozilla-central/source/toolkit/components/telemetry/Events.yaml#105)
+Take, for example, the [`manage`](https://searchfox.org/mozilla-central/rev/501eb4718d73870892d28f31a99b46f4783efaa0/toolkit/components/telemetry/Events.yaml#151)
  event in the `addonsManager` category.
 
 ```


### PR DESCRIPTION
Link check CI was intermittently failing on dxr.mozilla.org links,
so update them to searchfox.org links to the same content.