### PR TITLE
Describe Weekday regulars v1 and All-week regulars v1

### DIFF
--- a/src/concepts/segments.md
+++ b/src/concepts/segments.md
@@ -35,6 +35,18 @@ This segment contains clients who sent pings on _at least 14_ of the previous 27
 
 This segment contains clients who sent pings on _none_ of the previous 27 days. As of February 2020 this segment contained approximately 4% of DAU and its users had a 1-week retention of approximately 30%.
 
+### Weekday regulars v1
+
+`clients_last_seen.is_weekday_regular_v1`
+
+This segment contains clients in _Regular users v3_ who typically use the browser only on weekdays. This segment is responsible for a slight majority of the weekly seasonality in DAU for _Regular users v3_. Of the previous 27 days, these users submitted a ping on at most one weekend day (UTC). Due to differing timezones, we allow flexibility: the "weekend" could be Friday/Saturday, Saturday/Sunday, or Sunday/Monday; we only ask that each client is self-consistent for the 27 day period.
+
+## All-week regulars v1
+
+`clients_last_seen.is_allweek_regular_v1`
+
+This segment contains clients in _Regular users v3_ who do not fit in _Weekday regulars v1_ - clients that used the browser on a weekend at least twice in the previous 27 days. DAU for this segment does have some weekly seasonality, so some of the clients in this segment use the browser on weekdays preferentially, but not exclusively.
+
 ## Writing queries with segments
 
 When a segment is defined with respect to a user's _behavior_ (e.g. usage levels) 


### PR DESCRIPTION
DAU shows strong weekly seasonality. Some of this is due to users who are only present Monday-Friday (in their timezone). Weekday-only clients likely have a different usecase to all-week users: they may be on work or school computers. And post-COVID we saw a drop in weekday-only clients and an increase in all-week clients - so it’s worth tracking these separately.

“Weekday regulars v1” and “All-week regulars v1” are sub-segments of regular users v3: we do not try to classify non-regular users, because we may not have enough data points at hand to confidently classify a non-regular user as predominantly using the browser on weekdays. A broader usage threshold than “regular users v3” could have been chosen here, but nevertheless some threshold would have needed to be chosen: so for the sake of simplicity let’s just compute this for regular users v3.

Timezones: the `submission_date` of a ping does not necessarily match the local day that the browser was used. Monday in Australia starts on Sunday UTC. Therefore we should allow some flexibility around what is considered a “weekend”: for an individual client the weekend could be Friday/Saturday, Saturday/Sunday, or Sunday/Monday. Looking at [Australian/NZ clients](https://sql.telemetry.mozilla.org/queries/71717/source#180033), we see that there are many more weekday-only users if we allow Sunday/Monday UTC to be considered the weekend, and not many more weekday-only users if we allow Friday/Saturday UTC to be considered the weekend. For [US clients](https://sql.telemetry.mozilla.org/queries/71718/source#180035), the effect is reversed and shrunken.

The upshot is that we need to include Sunday/Monday UTC as “the weekend” so that we fairly represent AU/NZ weekday-only users. Including Friday/Saturday UTC as “the weekend” is less essential, but seems to add little noise to the segment so let’s just do it.

Out of the last 27 days, we can count the number of weekend days that a client was active, using the SQL snippet:

```
BIT_COUNT(
            cls.days_seen_bits & 0x0FFFFFFE & (
                ((udf.bits28_from_string('0000011000001100000110000011') << 14)
                    + udf.bits28_from_string('00000110000011')
                ) >> (8 - EXTRACT(DAYOFWEEK FROM cls.submission_date)))
        )
```

where `cls` refers to the `clients_last_seen` table. (We can add `OR` statements with copies of this snippet that add/subtract 1 from the day of week, to handle the other tizemones)

If we plot DAU for the weekday-only users (i.e. where the above snippet evaluates to 0), then we see a strongly-seasonal curve, albeit one that is nonzero on weekends because as usual we segment today’s data only on historical behaviour.

If we relax our strictness and allow one historical day of weekend use in the past 27 days, then we capture a lot more weekday use and only a little more weekend use (see weekday_only_dau vs almost_weekday_only_dau on https://sql.telemetry.mozilla.org/queries/71353/source#179227). If we allow two historical days of weekend use in the past 27 days, then we capture more weekday use but [start to include substantial weekend use](https://sql.telemetry.mozilla.org/queries/71374/source#179277). And the complement of this segment (all-week regular users) still has a lot of weekly seasonality - so I think two days is too much.

Finally, we should decide whether to have segments both for “weekday regulars” and “all-week regulars”, or just define “weekday regulars” and let people compute “all-week regulars” as all clients who are Regular Users v3 but not a weekday regular. It’s probably going to be easier for people if we do both for them.