### PR TITLE
Refactor public data sections

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,6 +28,7 @@
     * [Slicing Dimensions](metrics/dimensions.md)
   * [Metrics Standardization and Policy](metrics/policy.md)
 * [Analysis cookbooks](cookbooks/index.md)
+    * [Accessing Public Data](cookbooks/public_data.md)
     * [Accessing and working with BigQuery](cookbooks/bigquery.md)
         * [Access](cookbooks/bigquery/access.md)
         * [Writing Queries](cookbooks/bigquery/querying.md)
@@ -53,7 +54,6 @@
   * [Implementing Experiments](cookbooks/client_guidelines.md)
   * [Sending Events](cookbooks/events_best_practices.md)
   * [Sending a Custom Ping](cookbooks/new_ping.md)
-* [Public data](public_data/index.md)
 
 ---
 

--- a/src/concepts/gaining_access.md
+++ b/src/concepts/gaining_access.md
@@ -1,10 +1,17 @@
 # Accessing Telemetry data
 
-Access to telemetry data is limited to two groups:
+## Public Data
+
+Aggregated information on the Firefox user population (including hardware, operating system, and other usage characteristics) is available at the [Firefox Public Data Report](https://data.firefox.com/) portal.
+
+In addition, a set of curated datasets are available to the public for research purposes. See the [public data cookbook](../cookbooks/public_data.md) for more information.
+
+## Non-public Data
+
+Access to other Telemetry data is limited to two groups:
 
 1. Mozilla employees and contractors
-2. Contributors who have signed a [non-disclosure agreement](https://wiki.mozilla.org/NDA),
-   have a sustained track record of contribution, and have a demonstrated need to access this data
+2. Contributors who have signed a [non-disclosure agreement](https://wiki.mozilla.org/NDA), have a sustained track record of contribution, and have a demonstrated need to access this data
 
 If you are an employee or contractor, you should already have the necessary permissions.
 

--- a/src/cookbooks/public_data.md
+++ b/src/cookbooks/public_data.md
@@ -1,4 +1,4 @@
-# Public Data
+# Accessing Public Data
 
 A public dataset is a dataset in [BigQuery][bigquery] which is made available to the general public
 in BigQuery or through our [public HTTP endpoint][public_data_endpoint].


### PR DESCRIPTION
* Make public data a cookbook rather than a top-level
  section (we are try not to have too many top-level
  sections)
* Add some information on public data in the popular
  "gaining access" document