### PR TITLE
Move channel normalization and sampling under data pipeline reference

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -56,6 +56,8 @@
     * [HTTP Edge Server Specification](concepts/pipeline/http_edge_spec.md)
     * [Event Pipeline Detail](concepts/pipeline/event_pipeline.md)
     * [Schemas](concepts/pipeline/schemas.md)
+    * [Channel Normalization](concepts/channels/channel_normalization.md)
+    * [Sampling](concepts/sample_id.md)
   * [SQL Style Guide](concepts/sql_style.md)
   * [Telemetry Behavior Reference](concepts/index.md)
     * [History of Telemetry](concepts/history.md)
@@ -63,12 +65,9 @@
       * [Profile Creation](concepts/profile/profile_creation.md)
       * [Real World Usage](concepts/profile/realworldusage.md)
       * [Profile History](concepts/profile/profilehistory.md)
-    * [Channel Behavior](concepts/channels/index.md)
-      * [Channel Normalization and Querying](concepts/channels/channel_normalization.md)
     * [Census metrics](concepts/censuses.md)
     * [Engagement metrics](concepts/engagement.md)
     * [Segments](concepts/segments.md)
-    * [Sampling](concepts/sample_id.md)
   * [Project Glossary](tools/projects.md)
 
 ---

--- a/src/concepts/channels/channel_normalization.md
+++ b/src/concepts/channels/channel_normalization.md
@@ -1,26 +1,36 @@
-# Telemetry Channel Behavior
+# Channel Normalization
 
-In every ping there are two channels:
-- App Update Channel
-- Normalized Channel
+This document describes how the data pipeline normalizes channel information
+sent by Firefox and makes it accessible to data consumers.
 
-## Expected Channels
-The traditional channels we expect are:
+<!-- toc -->
+
+## What are Firefox channels?
+
+In addition to the the `release` channel, which is what we ship to most users,
+we also ship development versions of Firefox and an "extended support" (`esr`).
+The full list is:
+
 - `release`
 - `beta`
 - `aurora` (this is `dev-edition`, and [is just a beta repack][deved])
 - `nightly`
 - `esr`
 
+For more information on this topic, see the [Firefox Release Process page][fx_release_process].
+
 [deved]: https://developer.mozilla.org/en-US/Firefox/Developer_Edition
+[fx_release_process]: https://wiki.mozilla.org/Release_Management/Release_Process
 
 ## App Update Channel
-This is the channel reported by the application directly.
+
+This is the channel reported by Firefox.
 This could really be anything, but is usually one of the expected release channels listed above.
 
 For BigQuery tables corresponding to Telemetry Ping types, such as `main`, `crash` or `event`,
 the field here is called `app_update_channel` and is found in `metadata.uri`. For example:
-```
+
+```sql
 SELECT
   metadata.uri.app_update_channel
 FROM
@@ -40,7 +50,8 @@ There are a couple of exceptions, notably that variations on `nightly-cck-*` bec
 Normalized channel is available in the Telemetry Ping tables as a top-level field
 called `normalized_channel`.
 For example:
-```
+
+```sql
 SELECT
   normalized_channel
 FROM

--- a/src/concepts/channels/index.md
+++ b/src/concepts/channels/index.md
@@ -1,1 +1,0 @@
-# Channel Behavior


### PR DESCRIPTION
Since these are really things that the data pipeline does