### PR TITLE
Update UDF links

### DIFF
--- a/src/cookbooks/main_ping_exponential_histograms.md
+++ b/src/cookbooks/main_ping_exponential_histograms.md
@@ -95,7 +95,7 @@ Obviously this by itself is not particularly useful or meaningful - generally we
 
 ## Getting percentiles from a set of histograms
 
-Often, questions around histograms are framed as "what's the 99th percentile?" -- that is, what is the _maximum_ value that 99% of users experience: this helps give perspective on data which may have a number of weird outliers (a.k.a the _Bill Gates walks into a bar and everyone inside becomes a millionaire_ effect). Let's take an initial stab of grabbing some percentiles of the data we were looking at earlier using the [`histogram_merge`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_merge/udf.sql) and [`histogram_percentiles`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_percentiles/udf.sql) UDFs:
+Often, questions around histograms are framed as "what's the 99th percentile?" -- that is, what is the _maximum_ value that 99% of users experience: this helps give perspective on data which may have a number of weird outliers (a.k.a the _Bill Gates walks into a bar and everyone inside becomes a millionaire_ effect). Let's take an initial stab of grabbing some percentiles of the data we were looking at earlier using the [`mozfun.hist.merge`](https://mozilla.github.io/bigquery-etl/mozfun/hist/#merge) and [`mozfun.hist.percentiles`](https://mozilla.github.io/bigquery-etl/mozfun/hist/#percentiles) UDFs:
 
 ```sql
 WITH merged_histogram AS (

--- a/src/cookbooks/main_ping_exponential_histograms.md
+++ b/src/cookbooks/main_ping_exponential_histograms.md
@@ -213,7 +213,7 @@ The example above basically created one _giant_ histogram and then gathered the 
 
 A solution used by GLAM is to give each client "one vote": that is, the aggregate histogram for a client over a day must sum up to one. Even in the extreme case where all tab spinner measurements fall between `658ms` and `1000ms` (the range of the highest bucket), the _maximum_ number for that bucket is just "1".
 
-We can reproduce this approach by using the [`mozfun.hist.normalize`](https://mozilla.github.io/bigquery-etl/mozfun/hist/) UDF, which explicitly takes a set of histograms and makes sure that the values for each one sum up to exactly one:
+We can reproduce this approach by using the [`mozfun.hist.normalize`](https://mozilla.github.io/bigquery-etl/mozfun/hist/#normalize) UDF, which explicitly takes a set of histograms and makes sure that the values for each one sum up to exactly one:
 
 ```sql
 DECLARE four_twenty DEFAULT DATE('2020-04-20');

--- a/src/cookbooks/main_ping_exponential_histograms.md
+++ b/src/cookbooks/main_ping_exponential_histograms.md
@@ -56,7 +56,7 @@ In this representation, `bucket_count` and `range` represent the number of bucke
 `values` represents the number of instances in each of the buckets while `sum` represents the sum total of all histogram values recorded.
 Note how the first column has one bucket with no elements in it (the "165" bucket), this is because Firefox adds a zero-count bucket on the left and right edges of the data (unless that would be one of the extremes and that bucket already has a count in it, as is the case for the "1000" bucket in the last two examples).
 
-In general, it is best not to rely on this representation of the histogram in production code (it is quite likely to change in the future). Instead, use the [`json_extract_histogram`](https://github.com/mozilla/bigquery-etl/blob/master/udf/json_extract_histogram/udf.sql) user-defined-function (UDF) and extract out the fields you need: for example, to just get the `sum` for all the histograms above, you could modify the query above to something like:
+In general, it is best not to rely on this representation of the histogram in production code (it is quite likely to change in the future). Instead, use the [`mozfun.hist.extract`](https://mozilla.github.io/bigquery-etl/mozfun/hist/#extract) user-defined-function (UDF) and extract out the fields you need: for example, to just get the `sum` for all the histograms above, you could modify the query above to something like:
 
 ```sql
 WITH intermediate AS (

--- a/src/cookbooks/main_ping_exponential_histograms.md
+++ b/src/cookbooks/main_ping_exponential_histograms.md
@@ -213,7 +213,7 @@ The example above basically created one _giant_ histogram and then gathered the 
 
 A solution used by GLAM is to give each client "one vote": that is, the aggregate histogram for a client over a day must sum up to one. Even in the extreme case where all tab spinner measurements fall between `658ms` and `1000ms` (the range of the highest bucket), the _maximum_ number for that bucket is just "1".
 
-We can reproduce this approach by using the [`histogram_normalize`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_normalize/udf.sql) UDF, which explicitly takes a set of histograms and makes sure that the values for each one sum up to exactly one:
+We can reproduce this approach by using the [`mozfun.hist.normalize`](https://mozilla.github.io/bigquery-etl/mozfun/hist/) UDF, which explicitly takes a set of histograms and makes sure that the values for each one sum up to exactly one:
 
 ```sql
 DECLARE four_twenty DEFAULT DATE('2020-04-20');

--- a/src/cookbooks/main_ping_exponential_histograms.md
+++ b/src/cookbooks/main_ping_exponential_histograms.md
@@ -56,7 +56,7 @@ In this representation, `bucket_count` and `range` represent the number of bucke
 `values` represents the number of instances in each of the buckets while `sum` represents the sum total of all histogram values recorded.
 Note how the first column has one bucket with no elements in it (the "165" bucket), this is because Firefox adds a zero-count bucket on the left and right edges of the data (unless that would be one of the extremes and that bucket already has a count in it, as is the case for the "1000" bucket in the last two examples).
 
-In general, it is best not to rely on this representation of the histogram in production code (it is quite likely to change in the future). Instead, use the [`json_extract_histogram`](https://github.com/mozilla/bigquery-etl/blob/master/udf/json_extract_histogram.sql) user-defined-function (UDF) and extract out the fields you need: for example, to just get the `sum` for all the histograms above, you could modify the query above to something like:
+In general, it is best not to rely on this representation of the histogram in production code (it is quite likely to change in the future). Instead, use the [`json_extract_histogram`](https://github.com/mozilla/bigquery-etl/blob/master/udf/json_extract_histogram/udf.sql) user-defined-function (UDF) and extract out the fields you need: for example, to just get the `sum` for all the histograms above, you could modify the query above to something like:
 
 ```sql
 WITH intermediate AS (
@@ -95,7 +95,7 @@ Obviously this by itself is not particularly useful or meaningful - generally we
 
 ## Getting percentiles from a set of histograms
 
-Often, questions around histograms are framed as "what's the 99th percentile?" -- that is, what is the _maximum_ value that 99% of users experience: this helps give perspective on data which may have a number of weird outliers (a.k.a the _Bill Gates walks into a bar and everyone inside becomes a millionaire_ effect). Let's take an initial stab of grabbing some percentiles of the data we were looking at earlier using the [`histogram_merge`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_merge.sql) and [`histogram_percentiles`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_percentiles.sql) UDFs:
+Often, questions around histograms are framed as "what's the 99th percentile?" -- that is, what is the _maximum_ value that 99% of users experience: this helps give perspective on data which may have a number of weird outliers (a.k.a the _Bill Gates walks into a bar and everyone inside becomes a millionaire_ effect). Let's take an initial stab of grabbing some percentiles of the data we were looking at earlier using the [`histogram_merge`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_merge/udf.sql) and [`histogram_percentiles`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_percentiles/udf.sql) UDFs:
 
 ```sql
 WITH merged_histogram AS (
@@ -213,7 +213,7 @@ The example above basically created one _giant_ histogram and then gathered the 
 
 A solution used by GLAM is to give each client "one vote": that is, the aggregate histogram for a client over a day must sum up to one. Even in the extreme case where all tab spinner measurements fall between `658ms` and `1000ms` (the range of the highest bucket), the _maximum_ number for that bucket is just "1".
 
-We can reproduce this approach by using the [`histogram_normalize`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_normalize.sql) UDF, which explicitly takes a set of histograms and makes sure that the values for each one sum up to exactly one:
+We can reproduce this approach by using the [`histogram_normalize`](https://github.com/mozilla/bigquery-etl/blob/master/udf/histogram_normalize/udf.sql) UDF, which explicitly takes a set of histograms and makes sure that the values for each one sum up to exactly one:
 
 ```sql
 DECLARE four_twenty DEFAULT DATE('2020-04-20');

--- a/src/cookbooks/retention.md
+++ b/src/cookbooks/retention.md
@@ -104,7 +104,7 @@ When performing retention analysis it is important to understand that there are 
 
 It is good practice to always compute confidence intervals for retention metrics, especially when looking at specific slices of users or when making comparisons between different groups.
 
-The [Growth and Usage Dashboard](https://growth-stage.bespoke.nonprod.dataops.mozgcp.net/) provides confidence intervals automatically using a jackknife resampling method over `client_id` buckets. This confidence intervals generated using this method should be considered the "standard". We show below how to compute them using the data sources described above. These methods use UDFs [defined in bigquery-etl](https://github.com/mozilla/bigquery-etl/blob/master/udf_js/jackknife_ratio_ci.sql).
+The [Growth and Usage Dashboard](https://growth-stage.bespoke.nonprod.dataops.mozgcp.net/) provides confidence intervals automatically using a jackknife resampling method over `client_id` buckets. This confidence intervals generated using this method should be considered the "standard". We show below how to compute them using the data sources described above. These methods use UDFs [defined in bigquery-etl](https://github.com/mozilla/bigquery-etl/blob/master/udf_js/jackknife_ratio_ci/udf.sql).
 
 We also note that it is fairly simple to calculate a confidence interval using any statistical method appropriate for proportions. The queries given above provide both numerators and denominators, so feel free to calculate confidence intervals in the manner you prefer. However, if you want to replicate the standard confidence intervals, please work from the example queries below.
 


### PR DESCRIPTION
Some UDF paths changed as part of this refactor:
https://github.com/mozilla/bigquery-etl/pull/1272

Update relevant links to point to the  new location.