### PR TITLE
Update GCP data pipeline documentation 📝

### DIFF
--- a/src/concepts/pipeline/gcp_data_pipeline.md
+++ b/src/concepts/pipeline/gcp_data_pipeline.md
@@ -5,7 +5,7 @@ which is used to collect Telemetry data from our products and logs from various 
 
 The bulk of the data handled by this pipeline is Firefox Telemetry data, but the
 same tool-chain is used to collect, store, and analyze data coming from many
-sources, including Glean applications.
+sources, including [Glean](../glean.md) applications.
 
 Here is a simplified diagram of how data is ingested into the data warehouse.
 

--- a/src/concepts/pipeline/gcp_data_pipeline.md
+++ b/src/concepts/pipeline/gcp_data_pipeline.md
@@ -5,7 +5,7 @@ which is used to collect Telemetry data from our products and logs from various 
 
 The bulk of the data handled by this pipeline is Firefox Telemetry data, but the
 same tool-chain is used to collect, store, and analyze data coming from many
-sources.
+sources, including Glean applications.
 
 Here is a simplified diagram of how data is ingested into the data warehouse.
 


### PR DESCRIPTION
Make it more explicit that the GCP data pipeline powers Glean applications.